### PR TITLE
use_as_reply_to - formsupport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- NEW: The @submit-form entry-point now takes into account if a field is "marked"
+  with "use_as_reply_to" and use that field for "from" and "reply to".
+  [arsenico13]
 
 
 1.0.2 (2021-03-24)

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -134,7 +134,8 @@ class SubmitPost(Service):
             "default_subject", ""
         )
 
-        mfrom = self.get_reply_to()
+        mfrom = self.form_data.get("from", "") or self.block.get("default_from", "")
+        mreply_to = self.get_reply_to()
 
         if not subject or not mfrom:
             raise BadRequest(
@@ -165,7 +166,7 @@ class SubmitPost(Service):
         msg["Subject"] = subject
         msg["From"] = mfrom
         msg["To"] = mto
-        msg["Reply-To"] = mfrom
+        msg["Reply-To"] = mreply_to
         msg.replace_header("Content-Type", 'text/html; charset="utf-8"')
 
         self.manage_attachments(msg=msg)

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -117,9 +117,9 @@ class SubmitPost(Service):
         3. We use the fallback field: "default_from"
         """
 
-        sublocks = self.block.get("sublocks", "")
-        if sublocks:
-            for field in sublocks:
+        subblocks = self.block.get("subblocks", "")
+        if subblocks:
+            for field in subblocks:
                 if field.get("use_as_reply_to", False):
                     field_id = field.get("field_id", "")
 

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -70,9 +70,7 @@ class SubmitPost(Service):
                 ),
             )
 
-        if not self.block.get("store", False) and not self.block.get(
-            "send", False
-        ):
+        if not self.block.get("store", False) and not self.block.get("send", False):
             raise BadRequest(
                 translate(
                     _(
@@ -86,7 +84,10 @@ class SubmitPost(Service):
         if not self.form_data.get("data", []):
             raise BadRequest(
                 translate(
-                    _("empty_form_data", default="Empty form data.",),
+                    _(
+                        "empty_form_data",
+                        default="Empty form data.",
+                    ),
                     context=self.request,
                 )
             )
@@ -105,7 +106,7 @@ class SubmitPost(Service):
         return {}
 
     def get_reply_to(self):
-        """ This method retrieves the correct field to be used as 'reply to'.
+        """This method retrieves the correct field to be used as 'reply to'.
 
         Three "levels" of logic:
         1. If there is a field marked with 'use_as_reply_to' set to True, that
@@ -128,11 +129,9 @@ class SubmitPost(Service):
                 for data in self.form_data.get("data", ""):
                     if data.get("field_id", "") == field_id:
                         print(f"data['value']: {data['value']}\n")
-                        return data['value']
+                        return data["value"]
 
-        return self.form_data.get("from", "") or self.block.get(
-            "default_from", ""
-        )
+        return self.form_data.get("from", "") or self.block.get("default_from", "")
 
     def send_data(self):
         subject = self.form_data.get("subject", "") or self.block.get(

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -122,11 +122,10 @@ class SubmitPost(Service):
             for field in subblocks:
                 if field.get("use_as_reply_to", False):
                     field_id = field.get("field_id", "")
-
-            if field_id:
-                for data in self.form_data.get("data", ""):
-                    if data.get("field_id", "") == field_id:
-                        return data["value"]
+                    if field_id:
+                        for data in self.form_data.get("data", ""):
+                            if data.get("field_id", "") == field_id:
+                                return data["value"]
 
         return self.form_data.get("from", "") or self.block.get("default_from", "")
 

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -119,16 +119,13 @@ class SubmitPost(Service):
 
         sublocks = self.block.get("sublocks", "")
         if sublocks:
-            print(f"\n\nsublocks: {sublocks}")
             for field in sublocks:
                 if field.get("use_as_reply_to", False):
                     field_id = field.get("field_id", "")
 
-            print(f"Field id: {field_id}\n")
             if field_id:
                 for data in self.form_data.get("data", ""):
                     if data.get("field_id", "") == field_id:
-                        print(f"data['value']: {data['value']}\n")
                         return data["value"]
 
         return self.form_data.get("from", "") or self.block.get("default_from", "")

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -332,7 +332,7 @@ class TestMailSend(unittest.TestCase):
                 "default_subject": "block subject",
                 "default_from": "john@doe.com",
                 "send": True,
-                "sublocks": [
+                "subblocks": [
                     {
                         "field_id": "contact",
                         "field_type": "from",

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -329,7 +329,7 @@ class TestMailSend(unittest.TestCase):
             data={
                 "data": [
                     {"label": "Message", "value": "just want to say hi"},
-                    {"label": "Name", "value": "John"},
+                    {"label": "Name", "value": "Smith"},
                     {"field_id": "contact", "label": "Email", "value": "smith@doe.com"},
 
                 ],
@@ -344,8 +344,8 @@ class TestMailSend(unittest.TestCase):
             # Python 3 with Products.MailHost 4.10+
             msg = msg.decode("utf-8")
         self.assertIn("Subject: block subject", msg)
-        self.assertIn("From: john@doe.com", msg)
+        self.assertIn("From: smith@doe.com", msg)
         self.assertIn("To: site_addr@plone.com", msg)
-        self.assertIn("Reply-To: john@doe.com", msg)
+        self.assertIn("Reply-To: smith@doe.com", msg)
         self.assertIn("<strong>Message:</strong> just want to say hi", msg)
-        self.assertIn("<strong>Name:</strong> John", msg)
+        self.assertIn("<strong>Name:</strong> Smith", msg)

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -361,7 +361,7 @@ class TestMailSend(unittest.TestCase):
             # Python 3 with Products.MailHost 4.10+
             msg = msg.decode("utf-8")
         self.assertIn("Subject: block subject", msg)
-        self.assertIn("From: smith@doe.com", msg)
+        self.assertIn("From: john@doe.com", msg)
         self.assertIn("To: site_addr@plone.com", msg)
         self.assertIn("Reply-To: smith@doe.com", msg)
         self.assertIn("<strong>Message:</strong> just want to say hi", msg)

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -39,7 +39,9 @@ class TestMailSend(unittest.TestCase):
         self.anon_api_session.headers.update({"Accept": "application/json"})
 
         self.document = api.content.create(
-            type="Document", title="Example context", container=self.portal,
+            type="Document",
+            title="Example context",
+            container=self.portal,
         )
         self.document.blocks = {
             "text-id": {"@type": "text"},
@@ -61,7 +63,10 @@ class TestMailSend(unittest.TestCase):
 
     def submit_form(self, data):
         url = "{}/@submit-form".format(self.document_url)
-        response = self.api_session.post(url, json=data,)
+        response = self.api_session.post(
+            url,
+            json=data,
+        )
         transaction.commit()
         return response
 
@@ -145,7 +150,8 @@ class TestMailSend(unittest.TestCase):
         res = response.json()
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            res["message"], "Empty form data.",
+            res["message"],
+            "Empty form data.",
         )
 
     def test_email_not_send_if_block_id_is_correct_but_required_fields_missing(
@@ -168,10 +174,13 @@ class TestMailSend(unittest.TestCase):
         res = response.json()
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            res["message"], "Missing required field: subject or from.",
+            res["message"],
+            "Missing required field: subject or from.",
         )
 
-    def test_email_sent_with_site_recipient(self,):
+    def test_email_sent_with_site_recipient(
+        self,
+    ):
 
         self.document.blocks = {
             "form-id": {"@type": "form", "send": True},
@@ -202,7 +211,9 @@ class TestMailSend(unittest.TestCase):
         self.assertIn("<strong>Message:</strong> just want to say hi", msg)
         self.assertIn("<strong>Name:</strong> John", msg)
 
-    def test_email_sent_ignore_passed_recipient(self,):
+    def test_email_sent_ignore_passed_recipient(
+        self,
+    ):
 
         self.document.blocks = {
             "form-id": {"@type": "form", "send": True},
@@ -234,7 +245,9 @@ class TestMailSend(unittest.TestCase):
         self.assertIn("<strong>Message:</strong> just want to say hi", msg)
         self.assertIn("<strong>Name:</strong> John", msg)
 
-    def test_email_sent_with_block_recipient_if_set(self,):
+    def test_email_sent_with_block_recipient_if_set(
+        self,
+    ):
 
         self.document.blocks = {
             "text-id": {"@type": "text"},
@@ -270,7 +283,9 @@ class TestMailSend(unittest.TestCase):
         self.assertIn("<strong>Message:</strong> just want to say hi", msg)
         self.assertIn("<strong>Name:</strong> John", msg)
 
-    def test_email_sent_with_block_subject_if_set_and_not_passed(self,):
+    def test_email_sent_with_block_subject_if_set_and_not_passed(
+        self,
+    ):
 
         self.document.blocks = {
             "text-id": {"@type": "text"},
@@ -306,7 +321,9 @@ class TestMailSend(unittest.TestCase):
         self.assertIn("<strong>Message:</strong> just want to say hi", msg)
         self.assertIn("<strong>Name:</strong> John", msg)
 
-    def test_email_with_use_as_reply_to(self,):
+    def test_email_with_use_as_reply_to(
+        self,
+    ):
 
         self.document.blocks = {
             "text-id": {"@type": "text"},
@@ -319,7 +336,8 @@ class TestMailSend(unittest.TestCase):
                     {
                         "field_id": "contact",
                         "field_type": "from",
-                        "use_as_reply_to": True},
+                        "use_as_reply_to": True,
+                    },
                 ],
             },
         }
@@ -331,7 +349,6 @@ class TestMailSend(unittest.TestCase):
                     {"label": "Message", "value": "just want to say hi"},
                     {"label": "Name", "value": "Smith"},
                     {"field_id": "contact", "label": "Email", "value": "smith@doe.com"},
-
                 ],
                 "block_id": "form-id",
             },


### PR DESCRIPTION
If a field of the block is marked with "use_as_reply_to" set to True, we use that field for the "from" and "reply to" fields of the email.