### PR TITLE
Fix setup py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Changed the classifiers inside setup.py. This should fix some installation
+  issues.
+  [arsenico13]
 
 
 1.0.3 (2021-04-08)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "Framework :: Plone :: Addon",
         "Framework :: Plone :: 5.2",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
@@ -47,7 +47,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires="==2.7, >=3.6",
+    python_requires=">=3.6",
     install_requires=[
         "setuptools",
         # -*- Extra requirements: -*-


### PR DESCRIPTION
Found some problems installing this package, like this two:

```
pip install collective.volto.formsupport 
ERROR: Could not find a version that satisfies the requirement collective.volto.formsupport
ERROR: No matching distribution found for collective.volto.formsupport
```

and


```
Processing /tmp/tmpc6jj7fybget_dist/collective.volto.formsupport-1.0.3.tar.gz
collective.volto.formsupport requires Python '==2.7, >=3.6' but the running Python is 3.7.3
No .dist-info directory after successful pip install of /tmp/tmpc6jj7fybget_dist/collective.volto.formsupport-1.0.3.tar.gz
While:
  Installing instance1.
  Getting distribution for 'collective.volto.formsupport==1.0.3'.
```

(the latter, using zc.buildout==3.0.0b2)

This pr should fix that.