### PR TITLE
Fix stored data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,12 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Breaking change: changed the way to store data keys. Now we use field_id as key for Records.
+  [cekk]
+- Fix quoting in csv export.
+  [cekk]
+- Generate csv columns with proper field labels, and keep the form order.
+  [cekk]
 
 2.2.0 (2022-04-07)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,13 @@ The store is an adapter registered for *IFormDataStore* interface, so you can ov
 
 Only fields that are also in block settings are stored. Missing ones will be skipped.
 
+Each Record stores also two *service* attributes:
+
+- **fields_labels**: a mapping of field ids to field labels. This is useful when we export csv files, so we can labels for the columns.
+- **fields_order**: sorted list of field ids. This can be used in csv export to keep the order of fields.
+
+We store these attributes because the form can change over time and we want to have a snapshot of the fields in the Record.
+
 Block serializer
 ================
 

--- a/src/collective/volto/formsupport/datamanager/catalog.py
+++ b/src/collective/volto/formsupport/datamanager/catalog.py
@@ -13,8 +13,6 @@ from souper.soup import Record
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
-from zope.component import getUtility
-from plone.i18n.normalizer.interfaces import IIDNormalizer
 
 
 import logging

--- a/src/collective/volto/formsupport/datamanager/catalog.py
+++ b/src/collective/volto/formsupport/datamanager/catalog.py
@@ -77,18 +77,17 @@ class FormDataStore(object):
 
         fields = {x["field_id"]: x.get("label", x["field_id"]) for x in form_fields}
         record = Record()
-        # record.attrs["metadata"] = {}
-        normalizer = getUtility(IIDNormalizer)
+        fields_labels = {}
+        fields_order = []
         for field_data in data:
             field_id = field_data.get("field_id", "")
             value = field_data.get("value", "")
             if field_id in fields:
-                id = normalizer.normalize(fields[field_id])
-                record.attrs[id] = value
-                # record.attrs["metadata"][id] = {
-                #     "field_id": field_id,
-                #     "label": field.get("label", ""),
-                # }
+                record.attrs[field_id] = value
+                fields_labels[field_id] = fields[field_id]
+                fields_order.append(field_id)
+        record.attrs["fields_labels"] = fields_labels
+        record.attrs["fields_order"] = fields_order
         record.attrs["date"] = datetime.now()
         record.attrs["block_id"] = self.block_id
         return self.soup.add(record)

--- a/src/collective/volto/formsupport/datamanager/catalog.py
+++ b/src/collective/volto/formsupport/datamanager/catalog.py
@@ -15,10 +15,6 @@ from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
 
-import logging
-
-logger = logging.getLogger(__name__)
-
 
 @implementer(ICatalogFactory)
 class FormDataSoupCatalogFactory(object):

--- a/src/collective/volto/formsupport/profiles/default/metadata.xml
+++ b/src/collective/volto/formsupport/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1100</version>
+  <version>1200</version>
   <dependencies>
     <!--<dependency>profile-plone.app.dexterity:default</dependency>-->
   </dependencies>

--- a/src/collective/volto/formsupport/restapi/services/form_data/csv.py
+++ b/src/collective/volto/formsupport/restapi/services/form_data/csv.py
@@ -8,8 +8,46 @@ from zope.component import getMultiAdapter
 import csv
 import six
 
+SKIP_ATTRS = ["block_id", "fields_labels", "fields_order"]
+
 
 class FormDataExportGet(Service):
+    def __init__(self, context, request):
+        super().__init__(context, request)
+        self.form_fields_order = []
+        self.form_block = {}
+
+        blocks = getattr(context, "blocks", {})
+        if not blocks:
+            return
+        for id, block in blocks.items():
+            block_type = block.get("@type", "")
+            if block_type == "form":
+                self.form_block = block
+
+        if self.form_block:
+            for field in self.form_block.get("subblocks", []):
+                field_id = field["field_id"]
+                self.form_fields_order.append(field_id)
+
+    def get_ordered_keys(self, record):
+        """
+        We need this method because we want to maintain the fields order set in the form.
+        The form can also change during time, and each record can have different fields stored in it.
+        """
+        record_order = record.attrs.get("fields_order", [])
+        if record_order:
+            return record_order
+        order = []
+        # first add the keys that are currently in the form
+        for k in self.form_fields_order:
+            if k in record.attrs:
+                order.append(k)
+        # finally append the keys stored in the record but that are not in the form (maybe the form changed during time)
+        for k in record.attrs.keys():
+            if k not in order and k not in SKIP_ATTRS:
+                order.append(k)
+        return order
 
     def render(self):
         self.check_permission()
@@ -33,15 +71,18 @@ class FormDataExportGet(Service):
         rows = []
         for item in store.search():
             data = {}
-            for k, v in item.attrs.items():
-                if k == "block_id":
+            fields_labels = item.attrs.get("fields_labels", {})
+            for k in self.get_ordered_keys(item):
+                if k in SKIP_ATTRS:
                     continue
-                if k not in columns and k not in fixed_columns:
-                    columns.append(k)
-                data[k] = json_compatible(v)
+                value = item.attrs.get(k, None)
+                label = fields_labels.get(k, k)
+                if label not in columns and label not in fixed_columns:
+                    columns.append(label)
+                data[label] = json_compatible(value)
             rows.append(data)
         columns.extend(fixed_columns)
-        writer = csv.DictWriter(sbuf, fieldnames=columns, delimiter=",")
+        writer = csv.DictWriter(sbuf, fieldnames=columns, quoting=csv.QUOTE_ALL)
         writer.writeheader()
         for row in rows:
             writer.writerow(row)

--- a/src/collective/volto/formsupport/restapi/services/form_data/form_data.py
+++ b/src/collective/volto/formsupport/restapi/services/form_data/form_data.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from collective.volto.formsupport.interfaces import IFormDataStore
+from dataclasses import field
 from plone import api
+from plone.memoize import view
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
@@ -42,21 +44,34 @@ class FormData(object):
         result["form_data"] = data
         return result
 
-    def show_component(self):
-        if not api.user.has_permission("Modify portal content", obj=self.context):
-            return False
+    @property
+    @view.memoize
+    def form_block(self):
         blocks = getattr(self.context, "blocks", {})
         if isinstance(blocks, six.text_type):
             blocks = json.loads(blocks)
         if not blocks:
-            return False
+            return {}
         for block in blocks.values():
             if block.get("@type", "") == "form" and block.get("store", False):
-                return True
-        return False
+                return block
+        return {}
+
+    def show_component(self):
+        if not api.user.has_permission("Modify portal content", obj=self.context):
+            return False
+        return self.form_block and True or False
 
     def expand_records(self, record):
-        data = {k: json_compatible(v) for k, v in record.attrs.items()}
+        fields_labels = record.attrs.get("fields_labels", {})
+        data = {}
+        for k, v in record.attrs.items():
+            if k in ["fields_labels", "fields_order"]:
+                continue
+            data[k] = {
+                "value": json_compatible(v),
+                "label": fields_labels.get(k, k),
+            }
         data["id"] = record.intid
         return data
 

--- a/src/collective/volto/formsupport/restapi/services/form_data/form_data.py
+++ b/src/collective/volto/formsupport/restapi/services/form_data/form_data.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from collective.volto.formsupport.interfaces import IFormDataStore
-from dataclasses import field
 from plone import api
 from plone.memoize import view
 from plone.restapi.interfaces import IExpandableElement

--- a/src/collective/volto/formsupport/tests/test_store_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_store_action_form.py
@@ -148,8 +148,11 @@ class TestMailSend(unittest.TestCase):
             sorted(data["items"][0].keys()),
             ["block_id", "date", "id", "message", "name"],
         )
-        self.assertEqual(data["items"][0]["message"], "just want to say hi")
-        self.assertEqual(data["items"][0]["name"], "John")
+        self.assertEqual(
+            data["items"][0]["message"],
+            {"label": "Message", "value": "just want to say hi"},
+        )
+        self.assertEqual(data["items"][0]["name"], {"label": "Name", "value": "John"})
         response = self.submit_form(
             data={
                 "from": "sally@doe.com",
@@ -174,11 +177,11 @@ class TestMailSend(unittest.TestCase):
             sorted(data["items"][1].keys()),
             ["block_id", "date", "id", "message", "name"],
         )
-        sorted_data = sorted(data["items"], key=lambda x: x["name"])
-        self.assertEqual(sorted_data[0]["name"], "John")
-        self.assertEqual(sorted_data[0]["message"], "just want to say hi")
-        self.assertEqual(sorted_data[1]["name"], "Sally")
-        self.assertEqual(sorted_data[1]["message"], "bye")
+        sorted_data = sorted(data["items"], key=lambda x: x["name"]["value"])
+        self.assertEqual(sorted_data[0]["name"]["value"], "John")
+        self.assertEqual(sorted_data[0]["message"]["value"], "just want to say hi")
+        self.assertEqual(sorted_data[1]["name"]["value"], "Sally")
+        self.assertEqual(sorted_data[1]["message"]["value"], "bye")
 
         # clear data
         response = self.clear_data()
@@ -238,7 +241,7 @@ class TestMailSend(unittest.TestCase):
         response = self.export_csv()
         data = [*csv.reader(StringIO(response.text), delimiter=",")]
         self.assertEqual(len(data), 3)
-        self.assertEqual(data[0], ["message", "name", "date"])
+        self.assertEqual(data[0], ["Message", "Name", "date"])
         sorted_data = sorted(data[1:])
         self.assertEqual(sorted_data[0][:-1], ["bye", "Sally"])
         self.assertEqual(sorted_data[1][:-1], ["just want to say hi", "John"])

--- a/src/collective/volto/formsupport/upgrades.py
+++ b/src/collective/volto/formsupport/upgrades.py
@@ -4,6 +4,12 @@ from copy import deepcopy
 from plone import api
 from plone.dexterity.utils import iterSchemata
 from zope.schema import getFields
+from collective.volto.formsupport.interfaces import IFormDataStore
+from zope.component import getMultiAdapter
+from zope.globalrequest import getRequest
+from souper.soup import Record
+from zope.component import getUtility
+from plone.i18n.normalizer.interfaces import IIDNormalizer
 
 try:
     from collective.volto.blocksfield.field import BlocksField
@@ -78,3 +84,84 @@ def to_1100(context):  # noqa: C901 # pragma: no cover
                     if blocks:
                         fix_block(blocks, brain.getURL())
                         setattr(item, name, value)
+
+
+def to_1200(context):  # noqa: C901 # pragma: no cover
+    logger.info("### START CONVERSION STORED DATA ###")
+
+    def get_field_info_from_block(block, field_id):
+        normalizer = getUtility(IIDNormalizer)
+        for field in block.get("subblocks", []):
+            normalized_label = normalizer.normalize(field.get("label", ""))
+            if field_id == normalized_label:
+                return {"id": field["field_id"], "label": field.get("label", "")}
+            elif field_id == field["field_id"]:
+                return {"id": field["field_id"], "label": field.get("label", "")}
+        return {"id": field_id, "label": field_id}
+
+    def fix_data(blocks, context):
+        fixed = False
+        for block in blocks.values():
+            if block.get("@type", "") != "form":
+                continue
+            if not block.get("store", False):
+                continue
+            store = getMultiAdapter((context, getRequest()), IFormDataStore)
+            fixed = True
+            data = store.search()
+            for record in data:
+                labels = {}
+                new_record = Record()
+                for k, v in record.attrs.items():
+                    new_id = get_field_info_from_block(block=block, field_id=k)
+                    new_record.attrs[new_id["id"]] = v
+                    labels.update({new_id["id"]: new_id["label"]})
+                new_record.attrs["fields_labels"] = labels
+                # create new entry
+                store.soup.add(new_record)
+                # remove old one
+                store.delete(record.intid)
+        return fixed
+
+    fixed_contents = []
+    # fix root
+    portal = api.portal.get()
+    portal_blocks = getattr(portal, "blocks", "")
+    if portal_blocks:
+        blocks = json.loads(portal_blocks)
+        res = fix_data(blocks, portal)
+        if res:
+            fixed_contents.append("/")
+
+    # fix blocks in contents
+    pc = api.portal.get_tool(name="portal_catalog")
+    brains = pc()
+    tot = len(brains)
+    i = 0
+    for brain in brains:
+        i += 1
+        if i % 100 == 0:
+            logger.info("Progress: {}/{}".format(i, tot))
+        item = brain.getObject()
+        for schema in iterSchemata(item.aq_base):
+            for name, field in getFields(schema).items():
+                if name == "blocks":
+                    blocks = getattr(item, "blocks", {})
+                    if blocks:
+                        res = fix_data(blocks, item)
+                        if res:
+                            fixed_contents.append(brain.getPath())
+                elif HAS_BLOCKSFIELD and isinstance(field, BlocksField):
+                    value = field.get(item)
+                    if not value:
+                        continue
+                    if isinstance(value, str):
+                        continue
+                    blocks = value.get("blocks", {})
+                    if blocks:
+                        res = fix_data(blocks, item)
+                        if res:
+                            fixed_contents.append(brain.getPath())
+    logger.info("Fixed {} contents:".format(len(fixed_contents)))
+    for path in fixed_contents:
+        logger.info("- {}".format(path))

--- a/src/collective/volto/formsupport/upgrades.zcml
+++ b/src/collective/volto/formsupport/upgrades.zcml
@@ -11,4 +11,13 @@
         handler=".upgrades.to_1100"
         />
   </genericsetup:upgradeSteps>
+  <genericsetup:upgradeSteps
+    source="1100"
+    destination="1200"
+    profile="collective.volto.formsupport:default">
+    <genericsetup:upgradeStep
+        title="Store fieldid in records"
+        handler=".upgrades.to_1200"
+        />
+  </genericsetup:upgradeSteps>
 </configure>


### PR DESCRIPTION
We stored form data in souper Records using a calculated key that was the normalized field label.
This was a problem because for long labels, default normalizer strip the string to 50 chars.
The other problem was that these keys weren't too much unique.

Now we use field_id as key and store into records a mapping attribute to map field_id to its label.
This is needed because form fields can change during time and each record should keep a consistent labels mapping.

csv export also used ids for columns names, but probably for a consumer it will be better to have the labels.

I also made an upgrade-step that try to fix all data.