### PR TITLE
XML Sending and custom field mapping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 2.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow attaching an XML version of the form data to the sent email #22
+  [JeffersonBledsoe]
+- Allow the IDs of fields to be customised for CSV download and XML attaachments #22
+  [JeffersonBledsoe]
 
 
 2.7.0 (2023-04-03)

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
     :target: https://pypi.python.org/pypi/collective.volto.formsupport
     :alt: Egg Status
 
-.. image:: https://img.shields.io/pypi/pyversions/collective.volto.formsupport.svg?style=plastic   
+.. image:: https://img.shields.io/pypi/pyversions/collective.volto.formsupport.svg?style=plastic
     :target: https://pypi.python.org/pypi/collective.volto.formsupport/
     :alt: Supported - Python Versions
 
@@ -104,7 +104,20 @@ Send
 
 If block is set to send data, an email with form data will be sent to the recipient set in block settings or (if not set) to the site address.
 
-If ther is an ``attachments`` field in the POST data, these files will be attached to the emal sent.
+If there is an ``attachments`` field in the POST data, these files will be attached to the email sent.
+
+XML attachments
+^^^^^^^^^^^^^^^
+
+An XML copy of the data can be optionally attached to the sent email by configuring the volto block's `attachXml` option.
+
+The sent XML follows the same format as the feature in [collective.easyform](https://github.com/collective/collective.easyform). An example is shown below:
+
+```xml
+<?xml version='1.0' encoding='utf-8'?><form><field name="Custom field label">My value</field></form>
+```
+
+The field names in the XML will utilise the Data ID Mapping feature if it is used. Read more about this feature in the following Store section of the documentation.
 
 Store
 -----
@@ -121,6 +134,11 @@ Each Record stores also two *service* attributes:
 - **fields_order**: sorted list of field ids. This can be used in csv export to keep the order of fields.
 
 We store these attributes because the form can change over time and we want to have a snapshot of the fields in the Record.
+
+Data ID Mapping
+^^^^^^^^^^^^^^^
+
+The exported CSV file may need to be used by further processes which require specific values for the columns of the CSV. In such a case, the `Data ID Mapping` feature can be used to change the column name to custom text for each field.
 
 Block serializer
 ================

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = "\n\n".join(
 
 setup(
     name="collective.volto.formsupport",
-    version="2.6.3.dev0",
+    version="2.6.3.dev1",
     description="Add support for customizable forms in Volto",
     long_description=long_description,
     # Get more from https://pypi.org/classifiers/

--- a/src/collective/volto/formsupport/datamanager/catalog.py
+++ b/src/collective/volto/formsupport/datamanager/catalog.py
@@ -57,7 +57,15 @@ class FormDataStore(object):
                 form_block = deepcopy(block)
         if not form_block:
             return {}
-        return form_block.get("subblocks", [])
+
+        subblocks = form_block.get("subblocks", [])
+
+        # Add the 'custom_field_id' field back in as this isn't stored with each subblock
+        for index, field in enumerate(subblocks):
+            if form_block.get(field["field_id"]):
+                subblocks[index]["custom_field_id"] = form_block.get(field["field_id"])
+
+        return subblocks
 
     def add(self, data):
         form_fields = self.get_form_fields()
@@ -69,7 +77,10 @@ class FormDataStore(object):
             )
             return None
 
-        fields = {x["field_id"]: x.get("label", x["field_id"]) for x in form_fields}
+        fields = {
+            x["field_id"]: x.get("custom_field_id", x.get("label", x["field_id"]))
+            for x in form_fields
+        }
         record = Record()
         fields_labels = {}
         fields_order = []

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -345,7 +345,9 @@ class SubmitPost(Service):
         xmlRoot = Element("form")
 
         for field in self.filter_parameters():
-            SubElement(xmlRoot, "field", name=field["label"]).text = str(field["value"])
+            SubElement(
+                xmlRoot, "field", name=field.get("custom_field_id", field["label"])
+            ).text = str(field["value"])
 
         doc = ElementTree(xmlRoot)
         doc.write(output, encoding="utf-8", xml_declaration=True)

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -345,7 +345,7 @@ class SubmitPost(Service):
         xmlRoot = Element("form")
 
         for field in self.filter_parameters():
-            SubElement(xmlRoot, "field", name=field["label"]).text = field["value"]
+            SubElement(xmlRoot, "field", name=field["label"]).text = str(field["value"])
 
         doc = ElementTree(xmlRoot)
         doc.write(output, encoding="utf-8", xml_declaration=True)

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -326,10 +326,11 @@ class SubmitPost(Service):
                     file_data = file_data.encode("utf-8")
             else:
                 file_data = value
+            maintype, subtype = content_type.split("/")
             msg.add_attachment(
                 file_data,
-                maintype=content_type,
-                subtype=content_type,
+                maintype=maintype,
+                subtype=subtype,
                 filename=filename,
             )
 

--- a/src/collective/volto/formsupport/tests/test_store_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_store_action_form.py
@@ -251,3 +251,63 @@ class TestMailSend(unittest.TestCase):
         now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M")
         self.assertTrue(sorted_data[0][-1].startswith(now))
         self.assertTrue(sorted_data[1][-1].startswith(now))
+
+    def test_data_id_mapping(self):
+        self.document.blocks = {
+            "form-id": {
+                "@type": "form",
+                "store": True,
+                "test-field": "renamed-field",
+                "subblocks": [
+                    {
+                        "field_id": "message",
+                        "label": "Message",
+                        "field_type": "text",
+                    },
+                    {
+                        "field_id": "test-field",
+                        "label": "Test field",
+                        "field_type": "text",
+                    },
+                ],
+            },
+        }
+        transaction.commit()
+        response = self.submit_form(
+            data={
+                "from": "john@doe.com",
+                "data": [
+                    {"field_id": "message", "value": "just want to say hi"},
+                    {"field_id": "test-field", "value": "John"},
+                ],
+                "subject": "test subject",
+                "block_id": "form-id",
+            },
+        )
+
+        response = self.submit_form(
+            data={
+                "from": "sally@doe.com",
+                "data": [
+                    {"field_id": "message", "value": "bye"},
+                    {"field_id": "test-field", "value": "Sally"},
+                ],
+                "subject": "test subject",
+                "block_id": "form-id",
+            },
+        )
+
+        self.assertEqual(response.status_code, 204)
+        response = self.export_csv()
+        data = [*csv.reader(StringIO(response.text), delimiter=",")]
+        self.assertEqual(len(data), 3)
+        # Check that 'test-field' got renamed
+        self.assertEqual(data[0], ["Message", "renamed-field", "date"])
+        sorted_data = sorted(data[1:])
+        self.assertEqual(sorted_data[0][:-1], ["bye", "Sally"])
+        self.assertEqual(sorted_data[1][:-1], ["just want to say hi", "John"])
+
+        # check date column. Skip seconds because can change during test
+        now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M")
+        self.assertTrue(sorted_data[0][-1].startswith(now))
+        self.assertTrue(sorted_data[1][-1].startswith(now))


### PR DESCRIPTION
Requires collective/volto-form-block#52

## Todo

- [ ] Unit tests

This PR adds supports for attaching an XML file containing the data submitted in the form to the email. This feature is available in collective.easyform and may be useful to those transitioning to Volto. To further help transition [collective.easyform](https://github.com/collective/collective.easyform) users who may be reliant on specific field IDs when using collective.easyform, the ability to customise the label for sending/ downloading XML and CSV was also added.

The below video demonstrates the custom value mapping when downloading the CSV file. The XML after the video was the contents of the file attached to the email sent when submitting the form.

https://user-images.githubusercontent.com/30210785/203632407-ab1e51d1-3374-4613-b010-d2d823402630.mov

```xml
<?xml version='1.0' encoding='utf-8'?><form><field name="Custom field label">My value</field></form>
```