### PR TITLE
Allow changing the format of the contents of the email

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 - Allow forwarding request headers in the sent emails #27
   [JeffersonBledsoe]
+- Added support for sending emails as a table #31
+  [JeffersonBledsoe]
 
 
 2.7.0 (2023-04-03)

--- a/src/collective/volto/formsupport/browser/configure.zcml
+++ b/src/collective/volto/formsupport/browser/configure.zcml
@@ -24,4 +24,10 @@
         template="send_mail_template.pt"
         permission="zope2.View"
         />
+    <browser:page
+        for="*"
+        name="send_mail_template_table"
+        template="send_mail_template_table.pt"
+        permission="zope2.View"
+        />
 </configure>

--- a/src/collective/volto/formsupport/browser/send_mail_template_table.pt
+++ b/src/collective/volto/formsupport/browser/send_mail_template_table.pt
@@ -4,8 +4,7 @@
             url python:options.get('url', '');
             title python:options.get('title', '');">
   <table>
-    <caption i18n:translate="send_mail_text">Email results for ${title}</caption>
-    <!-- TODO:i18n attributes -->
+    <caption i18n:translate="send_mail_text_table">Form submission data for ${title}</caption>
     <thead>
       <tr role="row">
         <th scope="col"

--- a/src/collective/volto/formsupport/browser/send_mail_template_table.pt
+++ b/src/collective/volto/formsupport/browser/send_mail_template_table.pt
@@ -1,0 +1,31 @@
+<tal:root xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+  i18n:domain="collective.volto.formsupport"
+  define="parameters python:options.get('parameters', {});
+            url python:options.get('url', '');
+            title python:options.get('title', '');">
+  <table>
+    <caption i18n:translate="send_mail_text">Email results for ${title}</caption>
+    <!-- TODO:i18n attributes -->
+    <thead>
+      <tr role="row">
+        <th scope="col"
+          role="columnheader">Field</th>
+        <th scope="col"
+          role="columnheader">Value</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tal:field repeat="field parameters">
+        <tr role="row"
+          tal:define="value field/value|nothing;
+                      label field/label|nothing">
+          <th scope="row"
+            role="rowheader">${label}</th>
+          <td>${value}</td>
+        </tr>
+      </tal:field>
+    </tbody>
+  </table>
+</tal:root>
+
+

--- a/src/collective/volto/formsupport/locales/collective.volto.formsupport.pot
+++ b/src/collective/volto/formsupport/locales/collective.volto.formsupport.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-09-20 08:23+0000\n"
+"POT-Creation-Date: 2023-05-24 00:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,6 +27,10 @@ msgstr ""
 
 #: collective/volto/formsupport/captcha/hcaptcha.py:62
 msgid "HCaptcha Invisible"
+msgstr ""
+
+#: collective/volto/formsupport/captcha/honeypot.py:11
+msgid "Honeypot Support"
 msgstr ""
 
 #: collective/volto/formsupport/configure.zcml:33
@@ -62,32 +66,37 @@ msgid "Volto: Form support (uninstall)"
 msgstr ""
 
 #. Default: "Attachments too big. You uploaded ${uploaded_str}, but limit is ${max} MB. Try to compress files."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:152
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:158
 msgid "attachments_too_big"
 msgstr ""
 
 #. Default: "Block with @type \"form\" and id \"$block\" not found in this context: $context"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:93
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:99
 msgid "block_form_not_found_label"
 msgstr ""
 
 #. Default: "Empty form data."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:119
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:125
 msgid "empty_form_data"
 msgstr ""
 
+#. Default: "Error submitting form."
+#: collective/volto/formsupport/captcha/honeypot.py:28
+msgid "honeypot_error"
+msgstr ""
+
 #. Default: "Unable to send confirm email. Please retry later or contact site administator."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:66
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:72
 msgid "mail_send_exception"
 msgstr ""
 
 #. Default: "You need to set at least one form action between \"send\" and \"store\"."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:108
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:114
 msgid "missing_action"
 msgstr ""
 
 #. Default: "Missing block_id"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:86
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:92
 msgid "missing_blockid_label"
 msgstr ""
 
@@ -96,7 +105,12 @@ msgstr ""
 msgid "send_mail_text"
 msgstr ""
 
+#. Default: "Form submission data for ${title}"
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:7
+msgid "send_mail_text_table"
+msgstr ""
+
 #. Default: "Missing required field: subject or from."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:230
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:236
 msgid "send_required_field_missing"
 msgstr ""

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -39,6 +39,12 @@ class PostEventService(object):
 
 
 class SubmitPost(Service):
+    email_format_page_template_mapping = {
+        "": "send_mail_template",
+        "list": "send_mail_template",
+        "table": "send_mail_template_table",
+    }
+
     def __init__(self, context, request):
         super(SubmitPost, self).__init__(context, request)
 
@@ -276,8 +282,25 @@ class SubmitPost(Service):
             self.send_mail(msg=msg, charset=charset)
 
     def prepare_message(self):
+        template_name = self.email_format_page_template_mapping[
+            self.block.get("email_format", "")
+        ]
+
+        if not template_name:
+            # TODO: Actual i18n instead of placeholders here
+            # TODO: Display what format is currently selected
+            raise BadRequest(
+                translate(
+                    _(
+                        "missing_template_for_email_format",
+                        default="Missing email template for selected format",
+                    ),
+                    context=self.request,
+                )
+            )
+
         message_template = api.content.get_view(
-            name="send_mail_template",
+            name=template_name,
             context=self.context,
             request=self.request,
         )

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -282,9 +282,8 @@ class SubmitPost(Service):
             self.send_mail(msg=msg, charset=charset)
 
     def prepare_message(self):
-        template_name = self.email_format_page_template_mapping[
-            self.block.get("email_format", "")
-        ]
+        email_format = self.block.get("email_format", "")
+        template_name = self.email_format_page_template_mapping.get(email_format, "send_mail_template")
 
         if not template_name:
             # TODO: Actual i18n instead of placeholders here

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -41,12 +41,6 @@ class PostEventService(object):
 
 
 class SubmitPost(Service):
-    email_format_page_template_mapping = {
-        "": "send_mail_template",
-        "list": "send_mail_template",
-        "table": "send_mail_template_table",
-    }
-
     def __init__(self, context, request):
         super(SubmitPost, self).__init__(context, request)
 
@@ -284,22 +278,13 @@ class SubmitPost(Service):
             self.send_mail(msg=msg, charset=charset)
 
     def prepare_message(self):
+        email_format_page_template_mapping = {
+            "list": "send_mail_template",
+            "table": "send_mail_template_table",
+        }
         email_format = self.block.get("email_format", "")
-        template_name = self.email_format_page_template_mapping.get(email_format, "send_mail_template")
-
-        if not template_name:
-            # TODO: Actual i18n instead of placeholders here
-            # TODO: Display what format is currently selected
-            raise BadRequest(
-                translate(
-                    _(
-                        "missing_template_for_email_format",
-                        default="Missing email template for selected format",
-                    ),
-                    context=self.request,
-                )
-            )
-
+        template_name = email_format_page_template_mapping.get(email_format, 'send_mail_template')
+ 
         message_template = api.content.get_view(
             name=template_name,
             context=self.context,

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -283,8 +283,10 @@ class SubmitPost(Service):
             "table": "send_mail_template_table",
         }
         email_format = self.block.get("email_format", "")
-        template_name = email_format_page_template_mapping.get(email_format, 'send_mail_template')
- 
+        template_name = email_format_page_template_mapping.get(
+            email_format, "send_mail_template"
+        )
+
         message_template = api.content.get_view(
             name=template_name,
             context=self.context,

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -633,3 +633,9 @@ class TestMailSend(unittest.TestCase):
             msg,
         )
         self.assertIn(f"<td>{message}</td>", msg)
+
+    def test_email_body_formated_as_list(
+        self,
+    ):
+        # TODO: unit test for using 'list' explicitly as an email format
+        pass

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -19,7 +19,6 @@ import os
 
 
 class TestMailSend(unittest.TestCase):
-
     layer = VOLTO_FORMSUPPORT_API_FUNCTIONAL_TESTING
 
     def setUp(self):
@@ -123,7 +122,6 @@ class TestMailSend(unittest.TestCase):
         )
 
     def test_email_not_send_if_no_action_set(self):
-
         response = self.submit_form(
             data={"from": "john@doe.com", "block_id": "form-id"},
         )
@@ -138,7 +136,6 @@ class TestMailSend(unittest.TestCase):
     def test_email_not_send_if_block_id_is_correct_but_form_data_missing(
         self,
     ):
-
         self.document.blocks = {
             "form-id": {"@type": "form", "send": True},
         }
@@ -162,7 +159,6 @@ class TestMailSend(unittest.TestCase):
     def test_email_not_send_if_block_id_is_correct_but_required_fields_missing(
         self,
     ):
-
         self.document.blocks = {
             "form-id": {"@type": "form", "send": True},
         }
@@ -186,7 +182,6 @@ class TestMailSend(unittest.TestCase):
     def test_email_sent_with_site_recipient(
         self,
     ):
-
         self.document.blocks = {
             "form-id": {"@type": "form", "send": True},
         }
@@ -328,7 +323,6 @@ class TestMailSend(unittest.TestCase):
     def test_email_sent_with_block_recipient_if_set(
         self,
     ):
-
         self.document.blocks = {
             "text-id": {"@type": "text"},
             "form-id": {
@@ -366,7 +360,6 @@ class TestMailSend(unittest.TestCase):
     def test_email_sent_with_block_subject_if_set_and_not_passed(
         self,
     ):
-
         self.document.blocks = {
             "text-id": {"@type": "text"},
             "form-id": {
@@ -404,7 +397,6 @@ class TestMailSend(unittest.TestCase):
     def test_email_with_use_as_reply_to(
         self,
     ):
-
         self.document.blocks = {
             "text-id": {"@type": "text"},
             "form-id": {
@@ -450,7 +442,6 @@ class TestMailSend(unittest.TestCase):
     def test_email_field_used_as_bcc(
         self,
     ):
-
         self.document.blocks = {
             "text-id": {"@type": "text"},
             "form-id": {
@@ -497,7 +488,6 @@ class TestMailSend(unittest.TestCase):
     def test_send_attachment(
         self,
     ):
-
         self.document.blocks = {
             "text-id": {"@type": "text"},
             "form-id": {
@@ -579,3 +569,67 @@ class TestMailSend(unittest.TestCase):
             response.json()["message"],
         )
         self.assertEqual(len(self.mailhost.messages), 0)
+
+    def test_email_body_formated_as_table(
+        self,
+    ):
+        self.document.blocks = {
+            "form-id": {"@type": "form", "send": True, "email_format": "table"},
+        }
+        transaction.commit()
+
+        subject = "test subject"
+        name = "John"
+        message = "just want to say hi"
+
+        response = self.submit_form(
+            data={
+                "from": "john@doe.com",
+                "data": [
+                    {"label": "Message", "value": message},
+                    {"label": "Name", "value": name},
+                ],
+                "subject": subject,
+                "block_id": "form-id",
+            },
+        )
+        transaction.commit()
+        self.assertEqual(response.status_code, 204)
+        msg = self.mailhost.messages[0]
+        if isinstance(msg, bytes) and bytes is not str:
+            # Python 3 with Products.MailHost 4.10+
+            msg = msg.decode("utf-8")
+        self.assertIn(f"Subject: {subject}", msg)
+        self.assertIn("From: john@doe.com", msg)
+        self.assertIn("To: site_addr@plone.com", msg)
+        self.assertIn("Reply-To: john@doe.com", msg)
+        self.assertIn("<table>", msg)
+        self.assertIn("</table>", msg)
+        self.assertIn(f"<caption>Email results for {subject}</caption>", msg)
+        self.assertIn(
+            """<thead>
+      <tr role="row">
+        <th scope="col"
+          role="columnheader">Field</th>
+        <th scope="col"
+          role="columnheader">Value</th>
+      </tr>
+    </thead>""",
+            msg,
+        )
+        self.assertIn(
+            """<tr role="row">
+        <th scope="row"
+          role="rowheader">Name</th>
+      </tr>""",
+            msg,
+        )
+        self.assertIn(f"<td>{name}</td>", msg)
+        self.assertIn(
+            """<tr role="row">
+        <th scope="row"
+          role="rowheader">Message</th>
+      </tr>""",
+            msg,
+        )
+        self.assertIn(f"<td>{message}</td>", msg)

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -599,37 +599,37 @@ class TestMailSend(unittest.TestCase):
         if isinstance(msg, bytes) and bytes is not str:
             # Python 3 with Products.MailHost 4.10+
             msg = msg.decode("utf-8")
+
         self.assertIn(f"Subject: {subject}", msg)
         self.assertIn("From: john@doe.com", msg)
         self.assertIn("To: site_addr@plone.com", msg)
         self.assertIn("Reply-To: john@doe.com", msg)
+
         self.assertIn("<table>", msg)
         self.assertIn("</table>", msg)
-        self.assertIn(f"<caption>Email results for {subject}</caption>", msg)
+        # TODO: Is the document title the desired behaviour here? Or should it be the subject of the email
+        self.assertIn(
+            f"<caption>Email results for {self.document.title}</caption>", msg
+        )
         self.assertIn(
             """<thead>
       <tr role="row">
-        <th scope="col"
-          role="columnheader">Field</th>
-        <th scope="col"
-          role="columnheader">Value</th>
+        <th scope="col" role="columnheader">Field</th>
+        <th scope="col" role="columnheader">Value</th>
       </tr>
     </thead>""",
             msg,
         )
+
         self.assertIn(
             """<tr role="row">
-        <th scope="row"
-          role="rowheader">Name</th>
-      </tr>""",
+          <th scope="row" role="rowheader">Name</th>""",
             msg,
         )
         self.assertIn(f"<td>{name}</td>", msg)
         self.assertIn(
             """<tr role="row">
-        <th scope="row"
-          role="rowheader">Message</th>
-      </tr>""",
+          <th scope="row" role="rowheader">""",
             msg,
         )
         self.assertIn(f"<td>{message}</td>", msg)

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -2,6 +2,7 @@
 from collective.volto.formsupport.testing import (  # noqa: E501,
     VOLTO_FORMSUPPORT_API_FUNCTIONAL_TESTING,
 )
+from email.parser import Parser
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
@@ -10,6 +11,8 @@ from plone.app.testing import TEST_USER_ID
 from plone.registry.interfaces import IRegistry
 from plone.restapi.testing import RelativeSession
 from Products.MailHost.interfaces import IMailHost
+from six import StringIO
+import xml.etree.ElementTree as ET
 from zope.component import getUtility
 
 import transaction
@@ -697,5 +700,5 @@ class TestMailSend(unittest.TestCase):
         msg_contents = parsed_msgs.get_payload()[1].get_payload(decode=True)
         xml_tree = ET.fromstring(msg_contents)
         for index, field in enumerate(xml_tree):
-            self.assertEqual(field.get("name"), form_data[index]['label'])
-            self.assertEqual(field.text, form_data[index]['value'])
+            self.assertEqual(field.get("name"), form_data[index]["label"])
+            self.assertEqual(field.text, form_data[index]["value"])

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -609,7 +609,7 @@ class TestMailSend(unittest.TestCase):
         self.assertIn("</table>", msg)
         # TODO: Is the document title the desired behaviour here? Or should it be the subject of the email
         self.assertIn(
-            f"<caption>Email results for {self.document.title}</caption>", msg
+            f"<caption>Form submission data for {self.document.title}</caption>", msg
         )
         self.assertIn(
             """<thead>


### PR DESCRIPTION
Allow the email that is sent to either be styled as a list (current behaviour) or as a table (new behaviour from this PR).

## Markup of emails

List:

```html
<p>A new form has been submitted from <strong>Form</strong>:</p>
  <ul>
    
      <li>
          <strong>Field 1:</strong> List
      </li>
    
  </ul>

```

Table:

```html
 <table>
    <caption>Email results for Form</caption>
    <thead>
      <tr role="row">
        <th scope="col" role="columnheader">Field</th>
        <th scope="col" role="columnheader">Value</th>
      </tr>
    </thead>
    <tbody>
      
        <tr role="row">
          <th scope="row" role="rowheader">Field 1</th>
          <td>Table</td>
        </tr>
      
    </tbody>
  </table>
```