### PR TITLE
Add borders to table

### DIFF
--- a/src/collective/volto/formsupport/browser/send_mail_template_table.pt
+++ b/src/collective/volto/formsupport/browser/send_mail_template_table.pt
@@ -3,7 +3,7 @@
   define="parameters python:options.get('parameters', {});
             url python:options.get('url', '');
             title python:options.get('title', '');">
-  <table>
+  <table border="1">
     <caption i18n:translate="send_mail_text_table">Form submission data for ${title}</caption>
     <thead>
       <tr role="row">

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -608,9 +608,8 @@ class TestMailSend(unittest.TestCase):
         self.assertIn("To: site_addr@plone.com", msg)
         self.assertIn("Reply-To: john@doe.com", msg)
 
-        self.assertIn("<table>", msg)
+        self.assertIn("""<table border="1">""", msg)
         self.assertIn("</table>", msg)
-        # TODO: Is the document title the desired behaviour here? Or should it be the subject of the email
         self.assertIn(
             f"<caption>Form submission data for {self.document.title}</caption>", msg
         )


### PR DESCRIPTION
Adding the borders to the table format added in #31 to make the 'table' stying a bit more clear and the final email more readable

# Before

<img width="245" alt="border0" src="https://github.com/collective/collective.volto.formsupport/assets/30210785/8857ad33-de13-421c-bd88-4bf135c072c2">


# After

<img width="250" alt="border1" src="https://github.com/collective/collective.volto.formsupport/assets/30210785/8412484c-6417-4122-835e-977878f17efa">
