### PR TITLE
Align text in table formatting

### DIFF
--- a/src/collective/volto/formsupport/browser/send_mail_template_table.pt
+++ b/src/collective/volto/formsupport/browser/send_mail_template_table.pt
@@ -3,6 +3,11 @@
   define="parameters python:options.get('parameters', {});
             url python:options.get('url', '');
             title python:options.get('title', '');">
+  <style>
+    th {
+        text-align: start;
+    }
+  </style>
   <table border="1">
     <caption i18n:translate="send_mail_text_table">Form submission data for ${title}</caption>
     <thead>

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -308,18 +308,6 @@ class SubmitPost(Service):
             for x in self.block.get("subblocks", [])
             if x.get("field_type", "") == "attachment"
         ]
-
-        for field in self.form_data.get("data"):
-            for block_field in self.block.get("subblocks", []):
-                if block_field["field_id"] == field["field_id"] and block_field.get(
-                    "internal_value"
-                ):
-                    field["label"] = [
-                        k
-                        for k, v in block_field.get("internal_value").items()
-                        if v == field["value"]
-                    ][0]
-
         return [
             x
             for x in self.form_data.get("data", [])

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -308,6 +308,18 @@ class SubmitPost(Service):
             for x in self.block.get("subblocks", [])
             if x.get("field_type", "") == "attachment"
         ]
+
+        for field in self.form_data.get("data"):
+            for block_field in self.block.get("subblocks", []):
+                if block_field["field_id"] == field["field_id"] and block_field.get(
+                    "internal_value"
+                ):
+                    field["label"] = [
+                        k
+                        for k, v in block_field.get("internal_value").items()
+                        if v == field["value"]
+                    ][0]
+
         return [
             x
             for x in self.form_data.get("data", [])


### PR DESCRIPTION
Another small table formatting fix for #31 . This PR ensures all text is start-aligned rather than the default centre align of most browsers/ email clients