### PR TITLE
Handle undefined values in form submission

### DIFF
--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -201,7 +201,7 @@ class SubmitPost(Service):
                     if field_id:
                         for data in self.form_data.get("data", ""):
                             if data.get("field_id", "") == field_id:
-                                return data["value"]
+                                return data.get("value", "")
 
         return self.form_data.get("from", "") or self.block.get("default_from", "")
 
@@ -367,7 +367,7 @@ class SubmitPost(Service):
         for field in self.filter_parameters():
             SubElement(
                 xmlRoot, "field", name=field.get("custom_field_id", field["label"])
-            ).text = str(field["value"])
+            ).text = str(field.get("value", ""))
 
         doc = ElementTree(xmlRoot)
         doc.write(output, encoding="utf-8", xml_declaration=True)

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -25,8 +25,8 @@ class TestMailSend(unittest.TestCase):
     layer = VOLTO_FORMSUPPORT_API_FUNCTIONAL_TESTING
 
     def setUp(self):
-        import ZPublisher.HTTPRequest
-        ZPublisher.HTTPRequest.FORM_MEMORY_LIMIT = 2 ** 40
+        # import ZPublisher.HTTPRequest
+        # ZPublisher.HTTPRequest.FORM_MEMORY_LIMIT = 2 ** 40
 
         self.app = self.layer["app"]
         self.portal = self.layer["portal"]
@@ -69,8 +69,8 @@ class TestMailSend(unittest.TestCase):
 
         os.environ["FORM_ATTACHMENTS_LIMIT"] = ""
 
-        import ZPublisher.HTTPRequest
-        ZPublisher.HTTPRequest.FORM_MEMORY_LIMIT = 2 ** 20
+        # import ZPublisher.HTTPRequest
+        # ZPublisher.HTTPRequest.FORM_MEMORY_LIMIT = 2 ** 20
 
         transaction.commit()
 

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -537,7 +537,6 @@ class TestMailSend(unittest.TestCase):
     def test_send_attachment_validate_size(
         self,
     ):
-
         os.environ["FORM_ATTACHMENTS_LIMIT"] = "1"
         self.document.blocks = {
             "text-id": {"@type": "text"},

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -12,19 +12,22 @@ from plone.registry.interfaces import IRegistry
 from plone.restapi.testing import RelativeSession
 from Products.MailHost.interfaces import IMailHost
 from six import StringIO
-import xml.etree.ElementTree as ET
 from zope.component import getUtility
 
-import transaction
-import unittest
 import base64
 import os
+import transaction
+import unittest
+import xml.etree.ElementTree as ET
 
 
 class TestMailSend(unittest.TestCase):
     layer = VOLTO_FORMSUPPORT_API_FUNCTIONAL_TESTING
 
     def setUp(self):
+        import ZPublisher.HTTPRequest
+        ZPublisher.HTTPRequest.FORM_MEMORY_LIMIT = 2 ** 40
+
         self.app = self.layer["app"]
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
@@ -65,6 +68,9 @@ class TestMailSend(unittest.TestCase):
         }
 
         os.environ["FORM_ATTACHMENTS_LIMIT"] = ""
+
+        import ZPublisher.HTTPRequest
+        ZPublisher.HTTPRequest.FORM_MEMORY_LIMIT = 2 ** 20
 
         transaction.commit()
 
@@ -531,6 +537,7 @@ class TestMailSend(unittest.TestCase):
     def test_send_attachment_validate_size(
         self,
     ):
+
         os.environ["FORM_ATTACHMENTS_LIMIT"] = "1"
         self.document.blocks = {
             "text-id": {"@type": "text"},

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -25,9 +25,6 @@ class TestMailSend(unittest.TestCase):
     layer = VOLTO_FORMSUPPORT_API_FUNCTIONAL_TESTING
 
     def setUp(self):
-        # import ZPublisher.HTTPRequest
-        # ZPublisher.HTTPRequest.FORM_MEMORY_LIMIT = 2 ** 40
-
         self.app = self.layer["app"]
         self.portal = self.layer["portal"]
         self.portal_url = self.portal.absolute_url()
@@ -68,9 +65,6 @@ class TestMailSend(unittest.TestCase):
         }
 
         os.environ["FORM_ATTACHMENTS_LIMIT"] = ""
-
-        # import ZPublisher.HTTPRequest
-        # ZPublisher.HTTPRequest.FORM_MEMORY_LIMIT = 2 ** 20
 
         transaction.commit()
 


### PR DESCRIPTION
The form submission logic currently assumes that if a field is sent, it will have a value. While this is the normal case, we should be able to handle malformed requests