### PR TITLE
Send messages to emails signed as "use_as_bcc" independently from "send" flag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.1.3 (unreleased)
 ------------------
 
+- Send messages to emails signed as 'use_as_bcc' indipendently from 'send' flag.
+  [folix-01]
+
 - Update Italian translations.
   [cekk]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 3.1.3 (unreleased)
 ------------------
 
-- Send messages to emails signed as 'use_as_bcc' indipendently from 'send' flag.
+- Send messages to emails signed as 'use_as_bcc' independently from 'send' flag.
   [folix-01]
 
 - Update Italian translations.

--- a/src/collective/volto/formsupport/browser/send_mail_template.pt
+++ b/src/collective/volto/formsupport/browser/send_mail_template.pt
@@ -28,9 +28,13 @@
     <tal:element tal:replace="structure mail_footer" />
     <tal:element tal:condition="python:not mail_footer ">
       <p>
-        <span i18n:translate="send_mail_text"> A new form has been submitted from</span>
-        <a tal:attributes="href url"><strong tal:content="view/context/Title"> page</strong></a>
-      <p>
-    </tal:element>
+        <span i18n:translate="send_mail_text">
+          A new form has been submitted from</span>
+        <a tal:attributes="
+             href url;
+           "><strong tal:content="view/context/Title">
+            page</strong></a>
+        <p>
+        </p></p></tal:element>
   </footer>
 </tal:root>

--- a/src/collective/volto/formsupport/browser/send_mail_template.pt
+++ b/src/collective/volto/formsupport/browser/send_mail_template.pt
@@ -29,11 +29,7 @@
     <tal:element tal:condition="python:not mail_footer ">
       <p i18n:translate="send_mail_text">
         A new form has been submitted from
-        <a tal:attributes="
-             href url;
-           "><strong tal:content="url"
-                  i18n:name="url"
-          >url</strong></a>
+        <a tal:attributes="href url"><strong tal:content="context/Title" i18n:name="url">url</strong></a>
       </p>
     </tal:element>
   </footer>

--- a/src/collective/volto/formsupport/browser/send_mail_template.pt
+++ b/src/collective/volto/formsupport/browser/send_mail_template.pt
@@ -29,7 +29,7 @@
     <tal:element tal:condition="python:not mail_footer ">
       <p i18n:translate="send_mail_text">
         A new form has been submitted from
-        <a tal:attributes="href url"><strong tal:content="context/Title" i18n:name="url">url</strong></a>
+        <a tal:attributes="href url">{context/Title}</a>
       </p>
     </tal:element>
   </footer>

--- a/src/collective/volto/formsupport/browser/send_mail_template.pt
+++ b/src/collective/volto/formsupport/browser/send_mail_template.pt
@@ -27,10 +27,10 @@
   <footer>
     <tal:element tal:replace="structure mail_footer" />
     <tal:element tal:condition="python:not mail_footer ">
-      <p i18n:translate="send_mail_text">
-        A new form has been submitted from
-        <a tal:attributes="href url">${view/context/Title}</a>
-      </p>
+      <p>
+        <span i18n:translate="send_mail_text"> A new form has been submitted from</span>
+        <a tal:attributes="href url"><strong tal:content="view/context/Title"> page</strong></a>
+      <p>
     </tal:element>
   </footer>
 </tal:root>

--- a/src/collective/volto/formsupport/browser/send_mail_template.pt
+++ b/src/collective/volto/formsupport/browser/send_mail_template.pt
@@ -29,7 +29,7 @@
     <tal:element tal:condition="python:not mail_footer ">
       <p i18n:translate="send_mail_text">
         A new form has been submitted from
-        <a tal:attributes="href url">{context/Title}</a>
+        <a tal:attributes="href url">${view/context/Title}</a>
       </p>
     </tal:element>
   </footer>

--- a/src/collective/volto/formsupport/locales/collective.volto.formsupport.pot
+++ b/src/collective/volto/formsupport/locales/collective.volto.formsupport.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-06-12 14:56+0000\n"
+"POT-Creation-Date: 2024-08-30 14:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.volto.formsupport\n"
 
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:18
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:25
 msgid "Field"
 msgstr ""
 
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Uninstalls the collective.volto.formsupport add-on."
 msgstr ""
 
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:23
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:30
 msgid "Value"
 msgstr ""
 
@@ -74,17 +74,17 @@ msgid "Volto: Form support (uninstall)"
 msgstr ""
 
 #. Default: "Attachments too big. You uploaded ${uploaded_str}, but limit is ${max} MB. Try to compress files."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:215
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:223
 msgid "attachments_too_big"
 msgstr ""
 
 #. Default: "Block with @type \"form\" and id \"$block\" not found in this context: $context"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:130
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:138
 msgid "block_form_not_found_label"
 msgstr ""
 
 #. Default: "Empty form data."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:156
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:164
 msgid "empty_form_data"
 msgstr ""
 
@@ -94,40 +94,40 @@ msgid "honeypot_error"
 msgstr ""
 
 #. Default: "Unable to send confirm email. Please retry later or contact site administrator."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:76
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:84
 msgid "mail_send_exception"
 msgstr ""
 
 #. Default: "You need to set at least one form action between \"send\" and \"store\"."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:145
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:153
 msgid "missing_action"
 msgstr ""
 
 #. Default: "Missing block_id"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:123
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:131
 msgid "missing_blockid_label"
 msgstr ""
 
-#. Default: "A new form has been submitted from <a href=\"${DYNAMIC_CONTENT}\">${url}</a>"
-#: collective/volto/formsupport/browser/send_mail_template.pt:24
+#. Default: "A new form has been submitted from"
+#: collective/volto/formsupport/browser/send_mail_template.pt:31
 msgid "send_mail_text"
 msgstr ""
 
 #. Default: "Form submission data for ${title}"
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:15
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:19
 msgid "send_mail_text_table"
 msgstr ""
 
 #. Default: "Missing required field: subject or from."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:322
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:351
 msgid "send_required_field_missing"
 msgstr ""
 
 #. Default: "Email not valid in \"${field}\" field."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:187
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:195
 msgid "wrong_email"
 msgstr ""
 
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:246
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:254
 msgid "{email}'s OTP is wrong"
 msgstr ""

--- a/src/collective/volto/formsupport/locales/de/LC_MESSAGES/collective.volto.formsupport.po
+++ b/src/collective/volto/formsupport/locales/de/LC_MESSAGES/collective.volto.formsupport.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-06-12 14:56+0000\n"
+"POT-Creation-Date: 2024-08-30 14:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:18
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:25
 msgid "Field"
 msgstr ""
 
@@ -58,7 +58,7 @@ msgstr "Der eingegebene Code war falsch. Bitte geben Sie den neuen Code ein."
 msgid "Uninstalls the collective.volto.formsupport add-on."
 msgstr ""
 
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:23
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:30
 msgid "Value"
 msgstr ""
 
@@ -71,17 +71,17 @@ msgid "Volto: Form support (uninstall)"
 msgstr ""
 
 #. Default: "Attachments too big. You uploaded ${uploaded_str}, but limit is ${max} MB. Try to compress files."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:215
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:223
 msgid "attachments_too_big"
 msgstr "Anhang ist zu groß (${uploaded_str}). Die Größe darf ${max} MB nicht überschreiten. Versuchen Sie Dateien zu komprimieren."
 
 #. Default: "Block with @type \"form\" and id \"$block\" not found in this context: $context"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:130
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:138
 msgid "block_form_not_found_label"
 msgstr "Kein Formular-Block mit der ID \"$block\" in diesem Kontext gefunden: $context"
 
 #. Default: "Empty form data."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:156
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:164
 msgid "empty_form_data"
 msgstr "Leere Formulardaten."
 
@@ -91,42 +91,41 @@ msgid "honeypot_error"
 msgstr "Formular konnte nicht abgeschickt werden."
 
 #. Default: "Unable to send confirm email. Please retry later or contact site administrator."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:76
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:84
 #, fuzzy
 msgid "mail_send_exception"
 msgstr "Die Bestätigungsmail konnte nicht versandt werden. Bitte versuchen Sie es später erneut oder kontaktieren Sie die Seitenadministration."
 
 #. Default: "You need to set at least one form action between \"send\" and \"store\"."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:145
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:153
 msgid "missing_action"
 msgstr "Es muss mindestens eine Formular-Aktion gesetzt werden (\"E-Mail an Empfänger senden\" und/oder \"Kompilierte Daten speichern\")."
 
 #. Default: "Missing block_id"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:123
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:131
 msgid "missing_blockid_label"
 msgstr "Fehlende block_id"
 
-#. Default: "A new form has been submitted from <a href=\"${DYNAMIC_CONTENT}\">${url}</a>"
-#: collective/volto/formsupport/browser/send_mail_template.pt:24
-#, fuzzy
+#. Default: "A new form has been submitted from"
+#: collective/volto/formsupport/browser/send_mail_template.pt:31
 msgid "send_mail_text"
-msgstr "Auf der Seite ${url} wurde ein neues Formular eingereicht:"
+msgstr ""
 
 #. Default: "Form submission data for ${title}"
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:15
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:19
 msgid "send_mail_text_table"
 msgstr ""
 
 #. Default: "Missing required field: subject or from."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:322
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:351
 msgid "send_required_field_missing"
 msgstr "Erforderliches Feld fehlt: Betreff oder Absender"
 
 #. Default: "Email not valid in \"${field}\" field."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:187
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:195
 msgid "wrong_email"
 msgstr ""
 
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:246
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:254
 msgid "{email}'s OTP is wrong"
 msgstr ""

--- a/src/collective/volto/formsupport/locales/es/LC_MESSAGES/collective.volto.formsupport.po
+++ b/src/collective/volto/formsupport/locales/es/LC_MESSAGES/collective.volto.formsupport.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.volto.formsupport\n"
-"POT-Creation-Date: 2024-06-12 14:56+0000\n"
+"POT-Creation-Date: 2024-08-30 14:14+0000\n"
 "PO-Revision-Date: 2023-05-11 10:11-0400\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: ES <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "X-Is-Fallback-For: es-ar es-bo es-cl es-co es-cr es-do es-ec es-es es-sv es-gt es-hn es-mx es-ni es-pa es-py es-pe es-pr es-us es-uy es-ve\n"
 "X-Generator: Poedit 2.2.1\n"
 
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:18
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:25
 msgid "Field"
 msgstr ""
 
@@ -63,7 +63,7 @@ msgstr "El código que ingresaste es incorrecto, ingresa el nuevo."
 msgid "Uninstalls the collective.volto.formsupport add-on."
 msgstr "Desinstala o complemento collective.volto.formsupport."
 
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:23
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:30
 msgid "Value"
 msgstr ""
 
@@ -76,17 +76,17 @@ msgid "Volto: Form support (uninstall)"
 msgstr "Volto: Soporte a formularios (Desinstalar)"
 
 #. Default: "Attachments too big. You uploaded ${uploaded_str}, but limit is ${max} MB. Try to compress files."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:215
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:223
 msgid "attachments_too_big"
 msgstr "Adjuntos demasiado grandes. Subiste el archivo ${uploaded_str}, pero el límite es de ${max} MB. Intenta comprimir archivos."
 
 #. Default: "Block with @type \"form\" and id \"$block\" not found in this context: $context"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:130
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:138
 msgid "block_form_not_found_label"
 msgstr "Bloque con @type \"form\" y id \"${block}\" no encontrado en contexto: $context."
 
 #. Default: "Empty form data."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:156
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:164
 msgid "empty_form_data"
 msgstr "Formulario sem dados."
 
@@ -96,42 +96,41 @@ msgid "honeypot_error"
 msgstr ""
 
 #. Default: "Unable to send confirm email. Please retry later or contact site administrator."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:76
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:84
 #, fuzzy
 msgid "mail_send_exception"
 msgstr "No se puede enviar el correo electrónico de confirmación. Vuelva a intentarlo más tarde o póngase en contacto con el administrador del sitio."
 
 #. Default: "You need to set at least one form action between \"send\" and \"store\"."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:145
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:153
 msgid "missing_action"
 msgstr "Debe seleccionar al menos una acción entre \"guardar\" y \"enviar\"."
 
 #. Default: "Missing block_id"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:123
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:131
 msgid "missing_blockid_label"
 msgstr "Campo block_id no informado"
 
-#. Default: "A new form has been submitted from <a href=\"${DYNAMIC_CONTENT}\">${url}</a>"
-#: collective/volto/formsupport/browser/send_mail_template.pt:24
-#, fuzzy
+#. Default: "A new form has been submitted from"
+#: collective/volto/formsupport/browser/send_mail_template.pt:31
 msgid "send_mail_text"
-msgstr "Se ha enviado un nuevo formulario desde ${url}:"
+msgstr ""
 
 #. Default: "Form submission data for ${title}"
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:15
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:19
 msgid "send_mail_text_table"
 msgstr ""
 
 #. Default: "Missing required field: subject or from."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:322
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:351
 msgid "send_required_field_missing"
 msgstr "Campo obligatorio no presente: Asunto o remitente."
 
 #. Default: "Email not valid in \"${field}\" field."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:187
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:195
 msgid "wrong_email"
 msgstr ""
 
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:246
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:254
 msgid "{email}'s OTP is wrong"
 msgstr ""

--- a/src/collective/volto/formsupport/locales/it/LC_MESSAGES/collective.volto.formsupport.po
+++ b/src/collective/volto/formsupport/locales/it/LC_MESSAGES/collective.volto.formsupport.po
@@ -108,7 +108,7 @@ msgstr "Campo block_id mancante."
 #. Default: "A new form has been submitted from <a href=\"${DYNAMIC_CONTENT}\">${url}</a>"
 #: collective/volto/formsupport/browser/send_mail_template.pt:24
 msgid "send_mail_text"
-msgstr "Un nuovo form è stato compilato su <a href=\"${DYNAMIC_CONTENT}\">${url}</a>"
+msgstr "Un nuovo form è stato compilato su <a tal:attributes=\"href url\">${view/context/Title}</a>"
 
 #. Default: "Form submission data for ${title}"
 #: collective/volto/formsupport/browser/send_mail_template_table.pt:15

--- a/src/collective/volto/formsupport/locales/it/LC_MESSAGES/collective.volto.formsupport.po
+++ b/src/collective/volto/formsupport/locales/it/LC_MESSAGES/collective.volto.formsupport.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-06-12 14:56+0000\n"
+"POT-Creation-Date: 2024-08-30 14:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:18
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:25
 msgid "Field"
 msgstr ""
 
@@ -58,7 +58,7 @@ msgstr "Il codice che hai inserito è sbagliato, per favore prova con un altro."
 msgid "Uninstalls the collective.volto.formsupport add-on."
 msgstr "Disinstalla collective.volto.formsupport."
 
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:23
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:30
 msgid "Value"
 msgstr ""
 
@@ -71,17 +71,17 @@ msgid "Volto: Form support (uninstall)"
 msgstr "Volto: Form support (uninstall)"
 
 #. Default: "Attachments too big. You uploaded ${uploaded_str}, but limit is ${max} MB. Try to compress files."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:215
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:223
 msgid "attachments_too_big"
 msgstr "Allegati troppo grandi. Hai caricato ${uploaded_str}, ma il limite è di ${max} MB. Prova a comprimerli."
 
 #. Default: "Block with @type \"form\" and id \"$block\" not found in this context: $context"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:130
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:138
 msgid "block_form_not_found_label"
 msgstr "Blocco con @type \"form\" e id \"$block\" non trovato nel contesto: $context"
 
 #. Default: "Empty form data."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:156
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:164
 msgid "empty_form_data"
 msgstr "Form senza dati."
 
@@ -91,40 +91,40 @@ msgid "honeypot_error"
 msgstr "Errore nella sottomissione del form."
 
 #. Default: "Unable to send confirm email. Please retry later or contact site administrator."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:76
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:84
 msgid "mail_send_exception"
 msgstr "Impossibile inviare la mail di conferma. Per favore riprova più tardi o contatta l'amministratore del sito."
 
 #. Default: "You need to set at least one form action between \"send\" and \"store\"."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:145
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:153
 msgid "missing_action"
 msgstr "Devi selezionare almeno un'azione tra \"salva\" e \"invia\"."
 
 #. Default: "Missing block_id"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:123
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:131
 msgid "missing_blockid_label"
 msgstr "Campo block_id mancante."
 
-#. Default: "A new form has been submitted from <a href=\"${DYNAMIC_CONTENT}\">${url}</a>"
-#: collective/volto/formsupport/browser/send_mail_template.pt:24
+#. Default: "A new form has been submitted from"
+#: collective/volto/formsupport/browser/send_mail_template.pt:31
 msgid "send_mail_text"
-msgstr "Un nuovo form è stato compilato su <a tal:attributes=\"href url\">${view/context/Title}</a>"
+msgstr "Un nuovo form è stato compilato su"
 
 #. Default: "Form submission data for ${title}"
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:15
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:19
 msgid "send_mail_text_table"
 msgstr "Dati inviati per ${title}"
 
 #. Default: "Missing required field: subject or from."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:322
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:351
 msgid "send_required_field_missing"
 msgstr "Campo obbligatorio mancante: subject o from."
 
 #. Default: "Email not valid in \"${field}\" field."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:187
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:195
 msgid "wrong_email"
 msgstr "Email inserita non valida nel campo \"${field}\"."
 
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:246
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:254
 msgid "{email}'s OTP is wrong"
 msgstr "Il codice OTP per {email} è errato."

--- a/src/collective/volto/formsupport/locales/pt_BR/LC_MESSAGES/collective.volto.formsupport.po
+++ b/src/collective/volto/formsupport/locales/pt_BR/LC_MESSAGES/collective.volto.formsupport.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-06-12 14:56+0000\n"
+"POT-Creation-Date: 2024-08-30 14:14+0000\n"
 "PO-Revision-Date: 2021-05-11 18:49-0300\n"
 "Last-Translator: Érico Andrei <ericof@plone.org>, 2021\n"
 "Language-Team: Portuguese (https://www.transifex.com/plone/teams/14552/pt/)\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Language: pt_BR\n"
 "X-Generator: Poedit 2.4.3\n"
 
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:18
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:25
 msgid "Field"
 msgstr ""
 
@@ -60,7 +60,7 @@ msgstr ""
 msgid "Uninstalls the collective.volto.formsupport add-on."
 msgstr "Desinstala o complemento collective.volto.formsupport."
 
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:23
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:30
 msgid "Value"
 msgstr ""
 
@@ -73,17 +73,17 @@ msgid "Volto: Form support (uninstall)"
 msgstr "Volto: Suporte a formulários (Desinstalar)"
 
 #. Default: "Attachments too big. You uploaded ${uploaded_str}, but limit is ${max} MB. Try to compress files."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:215
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:223
 msgid "attachments_too_big"
 msgstr ""
 
 #. Default: "Block with @type \"form\" and id \"$block\" not found in this context: $context"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:130
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:138
 msgid "block_form_not_found_label"
 msgstr "Bloco com @type \"form\" e id \"${block}\" não encontrado no contexto: $context."
 
 #. Default: "Empty form data."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:156
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:164
 msgid "empty_form_data"
 msgstr "Formulário sem dados."
 
@@ -93,41 +93,40 @@ msgid "honeypot_error"
 msgstr ""
 
 #. Default: "Unable to send confirm email. Please retry later or contact site administrator."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:76
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:84
 msgid "mail_send_exception"
 msgstr ""
 
 #. Default: "You need to set at least one form action between \"send\" and \"store\"."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:145
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:153
 msgid "missing_action"
 msgstr "Você deve selecionar pelo menos uma ação entre \"salvar\" e \"enviar\"."
 
 #. Default: "Missing block_id"
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:123
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:131
 msgid "missing_blockid_label"
 msgstr "Campo  block_id não informado"
 
-#. Default: "A new form has been submitted from <a href=\"${DYNAMIC_CONTENT}\">${url}</a>"
-#: collective/volto/formsupport/browser/send_mail_template.pt:24
-#, fuzzy
+#. Default: "A new form has been submitted from"
+#: collective/volto/formsupport/browser/send_mail_template.pt:31
 msgid "send_mail_text"
-msgstr "Um novo formulário foi preenchido em ${url}:"
+msgstr ""
 
 #. Default: "Form submission data for ${title}"
-#: collective/volto/formsupport/browser/send_mail_template_table.pt:15
+#: collective/volto/formsupport/browser/send_mail_template_table.pt:19
 msgid "send_mail_text_table"
 msgstr ""
 
 #. Default: "Missing required field: subject or from."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:322
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:351
 msgid "send_required_field_missing"
 msgstr "Campo obrigatório não presente: Assunto ou remetente."
 
 #. Default: "Email not valid in \"${field}\" field."
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:187
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:195
 msgid "wrong_email"
 msgstr ""
 
-#: collective/volto/formsupport/restapi/services/submit_form/post.py:246
+#: collective/volto/formsupport/restapi/services/submit_form/post.py:254
 msgid "{email}'s OTP is wrong"
 msgstr ""

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -643,7 +643,8 @@ class TestMailSend(unittest.TestCase):
                 "@type": "form",
                 "default_subject": "block subject",
                 "default_from": "john@doe.com",
-                "send": ["recipient"],
+                "send": False,
+                "store": True,
                 "subblocks": [
                     {
                         "field_id": "contact",
@@ -683,15 +684,13 @@ class TestMailSend(unittest.TestCase):
         transaction.commit()
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(self.mailhost.messages), 2)
-        msg = self.mailhost.messages[0]
-        bcc_msg = self.mailhost.messages[1]
-        if isinstance(msg, bytes) and bytes is not str:
-            # Python 3 with Products.MailHost 4.10+
-            msg = msg.decode("utf-8")
+        self.assertEqual(len(self.mailhost.messages), 1)
+
+        bcc_msg = self.mailhost.messages[0]
+
+        if isinstance(bcc_msg, bytes) and bytes is not str:
             bcc_msg = bcc_msg.decode("utf-8")
-        self.assertIn("To: site_addr@plone.com", msg)
-        self.assertNotIn("To: smith@doe.com", msg)
+
         self.assertNotIn("To: site_addr@plone.com", bcc_msg)
         self.assertIn("To: smith@doe.com", bcc_msg)
 


### PR DESCRIPTION
email were not send to bcc email if was not send to form recipient.

Note: use_as_bcc it's only the way to name it, is not really being used as bcc but it was sent separately