### PR TITLE
Format csv date

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 3.2.1 (unreleased)
 ------------------
 
-- formate date in csv (as in email)
+- format date in csv (as in email)
   [mamico]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- formate date in csv (as in email)
+  [mamico]
 
 
 3.2.0 (2024-11-15)

--- a/src/collective/volto/formsupport/restapi/services/form_data/csv.py
+++ b/src/collective/volto/formsupport/restapi/services/form_data/csv.py
@@ -69,7 +69,7 @@ class FormDataExportGet(Service):
 
     def format_date(self, value):
         return api.portal.get_localized_time(value)
-    
+
     def get_data(self):
         store = getMultiAdapter((self.context, self.request), IFormDataStore)
         sbuf = StringIO()

--- a/src/collective/volto/formsupport/restapi/services/form_data/csv.py
+++ b/src/collective/volto/formsupport/restapi/services/form_data/csv.py
@@ -1,5 +1,6 @@
 from collective.volto.formsupport.interfaces import IFormDataStore
 from io import StringIO
+from plone import api
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from zope.component import getMultiAdapter
@@ -14,6 +15,7 @@ class FormDataExportGet(Service):
     def __init__(self, context, request):
         super().__init__(context, request)
         self.form_fields_order = []
+        self.form_fields_type = {}
         self.form_block = {}
 
         blocks = getattr(context, "blocks", {})
@@ -28,6 +30,7 @@ class FormDataExportGet(Service):
             for field in self.form_block.get("subblocks", []):
                 field_id = field["field_id"]
                 self.form_fields_order.append(field_id)
+                self.form_fields_type[field_id] = field.get("field_type", "text")
 
     def get_ordered_keys(self, record):
         """
@@ -64,6 +67,9 @@ class FormDataExportGet(Service):
     def get_fields_labels(self, item):
         return item.attrs.get("fields_labels", {})
 
+    def format_date(self, value):
+        return api.portal.get_localized_time(value)
+    
     def get_data(self):
         store = getMultiAdapter((self.context, self.request), IFormDataStore)
         sbuf = StringIO()
@@ -81,7 +87,10 @@ class FormDataExportGet(Service):
                 label = fields_labels.get(k, k)
                 if label not in columns and label not in fixed_columns:
                     columns.append(label)
-                data[label] = json_compatible(value)
+                if self.form_fields_type.get(k) == "date":
+                    data[label] = self.format_date(value)
+                else:
+                    data[label] = json_compatible(value)
             for k in fixed_columns:
                 # add fixed columns values
                 value = item.attrs.get(k, None)

--- a/src/collective/volto/formsupport/tests/test_store_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_store_action_form.py
@@ -214,6 +214,12 @@ class TestMailStore(unittest.TestCase):
                         "field_id": "name",
                         "field_type": "text",
                     },
+                    {
+                        "label": "When",
+                        "field_id": "when",
+                        "field_type": "date",
+                    },
+
                 ],
             },
         }
@@ -224,6 +230,7 @@ class TestMailStore(unittest.TestCase):
                 "data": [
                     {"field_id": "message", "value": "just want to say hi"},
                     {"field_id": "name", "value": "John"},
+                    {"field_id": "when", "value": "2024-11-10"},
                     {"field_id": "foo", "value": "skip this"},
                 ],
                 "subject": "test subject",
@@ -237,6 +244,7 @@ class TestMailStore(unittest.TestCase):
                 "data": [
                     {"field_id": "message", "value": "bye"},
                     {"field_id": "name", "value": "Sally"},
+                    {"field_id": "when", "value": "2024-11-30"},
                 ],
                 "subject": "test subject",
                 "block_id": "form-id",
@@ -247,10 +255,10 @@ class TestMailStore(unittest.TestCase):
         response = self.export_csv()
         data = [*csv.reader(StringIO(response.text), delimiter=",")]
         self.assertEqual(len(data), 3)
-        self.assertEqual(data[0], ["Message", "Name", "date"])
+        self.assertEqual(data[0], ["Message", "Name", "When", "date"])
         sorted_data = sorted(data[1:])
-        self.assertEqual(sorted_data[0][:-1], ["bye", "Sally"])
-        self.assertEqual(sorted_data[1][:-1], ["just want to say hi", "John"])
+        self.assertEqual(sorted_data[0][:-1], ["bye", "Sally", "Nov 30, 2024"])
+        self.assertEqual(sorted_data[1][:-1], ["just want to say hi", "John", "Nov 10, 2024"])
 
         # check date column. Skip seconds because can change during test
         now = datetime.now().strftime("%Y-%m-%dT%H:%M")

--- a/src/collective/volto/formsupport/tests/test_store_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_store_action_form.py
@@ -219,7 +219,6 @@ class TestMailStore(unittest.TestCase):
                         "field_id": "when",
                         "field_type": "date",
                     },
-
                 ],
             },
         }
@@ -258,7 +257,9 @@ class TestMailStore(unittest.TestCase):
         self.assertEqual(data[0], ["Message", "Name", "When", "date"])
         sorted_data = sorted(data[1:])
         self.assertEqual(sorted_data[0][:-1], ["bye", "Sally", "Nov 30, 2024"])
-        self.assertEqual(sorted_data[1][:-1], ["just want to say hi", "John", "Nov 10, 2024"])
+        self.assertEqual(
+            sorted_data[1][:-1], ["just want to say hi", "John", "Nov 10, 2024"]
+        )
 
         # check date column. Skip seconds because can change during test
         now = datetime.now().strftime("%Y-%m-%dT%H:%M")


### PR DESCRIPTION
return locallized date in csv (as in email). Add the possibility to change behavior overriding a method `format_date`
