### PR TITLE
Global form submissions

### DIFF
--- a/src/collective/volto/formsupport/adapters/post.py
+++ b/src/collective/volto/formsupport/adapters/post.py
@@ -96,7 +96,7 @@ class PostAdapter:
                 return {}
         for id, block in blocks.items():
             # Prefer local forms it they're available, fall back to global form
-            if id != block_id and id != global_form_id and block.get("global_form_id" != global_form_id):
+            if id != block_id and id != global_form_id and block.get("global_form_id") != global_form_id:
                 continue
             block_type = block.get("@type", "")
             if block_type != "form":

--- a/src/collective/volto/formsupport/adapters/post.py
+++ b/src/collective/volto/formsupport/adapters/post.py
@@ -82,21 +82,22 @@ class PostAdapter:
 
     def get_block_data(self, block_id, global_form_id):
         blocks = get_blocks(self.context)
+        global_form_id = global_form_id
+        if global_form_id:
+            global_forms = api.portal.get_registry_record(
+                GLOBAL_FORM_REGISTRY_RECORD_ID
+            )
+            if global_forms:
+                blocks = {**blocks, **global_forms}
         if not blocks:
-            global_form_id = global_form_id
-            if global_form_id:
-                global_forms = api.portal.get_registry_record(
-                    GLOBAL_FORM_REGISTRY_RECORD_ID
-                )
-                if global_forms:
-                    blocks = global_forms
-                else:
-                    return {}
-            else:
-                return {}
+            return {}
         for id, block in blocks.items():
             # Prefer local forms it they're available, fall back to global form
-            if id != block_id and id != global_form_id and block.get("global_form_id") != global_form_id:
+            if (
+                id != block_id
+                and id != global_form_id
+                and block.get("global_form_id") != global_form_id
+            ):
                 continue
             block_type = block.get("@type", "")
             if block_type != "form":

--- a/src/collective/volto/formsupport/adapters/post.py
+++ b/src/collective/volto/formsupport/adapters/post.py
@@ -96,7 +96,7 @@ class PostAdapter:
                 return {}
         for id, block in blocks.items():
             # Prefer local forms it they're available, fall back to global form
-            if id != block_id and id != global_form_id:
+            if id != block_id and id != global_form_id and block.get("global_form_id" != global_form_id):
                 continue
             block_type = block.get("@type", "")
             if block_type != "form":

--- a/src/collective/volto/formsupport/adapters/post.py
+++ b/src/collective/volto/formsupport/adapters/post.py
@@ -18,6 +18,11 @@ import math
 import os
 
 
+GLOBAL_FORM_REGISTRY_RECORD_ID = (
+    "collective.volto.formsupport.interfaces.IGlobalFormStore.global_forms_config"
+)
+
+
 @implementer(IPostAdapter)
 @adapter(Interface, Interface)
 class PostAdapter:
@@ -29,8 +34,12 @@ class PostAdapter:
         self.request = request
         self.form_data = self.extract_data_from_request()
         self.block_id = self.form_data.get("block_id", "")
+        self.global_form_id = self.extract_data_from_request().get("global_form_id", "")
         if self.block_id:
-            self.block = self.get_block_data(block_id=self.block_id)
+            self.block = self.get_block_data(
+                block_id=self.block_id,
+                global_form_id=self.form_data.get("global_form_id"),
+            )
 
     def __call__(self):
         """
@@ -50,7 +59,10 @@ class PostAdapter:
         fixed_fields = []
         transforms = api.portal.get_tool(name="portal_transforms")
 
-        block = self.get_block_data(block_id=form_data.get("block_id", ""))
+        block = self.get_block_data(
+            block_id=form_data.get("block_id", ""),
+            global_form_id=form_data.get("global_form_id"),
+        )
         block_fields = [x.get("field_id", "") for x in block.get("subblocks", [])]
 
         for form_field in form_data.get("data", []):
@@ -68,12 +80,23 @@ class PostAdapter:
 
         return form_data
 
-    def get_block_data(self, block_id):
+    def get_block_data(self, block_id, global_form_id):
         blocks = get_blocks(self.context)
         if not blocks:
-            return {}
+            global_form_id = global_form_id
+            if global_form_id:
+                global_forms = api.portal.get_registry_record(
+                    GLOBAL_FORM_REGISTRY_RECORD_ID
+                )
+                if global_forms:
+                    blocks = global_forms
+                else:
+                    return {}
+            else:
+                return {}
         for id, block in blocks.items():
-            if id != block_id:
+            # Prefer local forms it they're available, fall back to global form
+            if id != block_id and id != global_form_id:
                 continue
             block_type = block.get("@type", "")
             if block_type != "form":

--- a/src/collective/volto/formsupport/adapters/post.py
+++ b/src/collective/volto/formsupport/adapters/post.py
@@ -1,6 +1,7 @@
 from collective.volto.formsupport import _
 from collective.volto.formsupport.interfaces import ICaptchaSupport
 from collective.volto.formsupport.interfaces import IPostAdapter
+from collective.volto.formsupport.restapi import GLOBAL_FORM_REGISTRY_RECORD_ID
 from collective.volto.formsupport.utils import get_blocks
 from collective.volto.otp.utils import validate_email_token
 from copy import deepcopy
@@ -16,11 +17,6 @@ from zope.interface import Interface
 
 import math
 import os
-
-
-GLOBAL_FORM_REGISTRY_RECORD_ID = (
-    "collective.volto.formsupport.interfaces.IGlobalFormStore.global_forms_config"
-)
 
 
 @implementer(IPostAdapter)

--- a/src/collective/volto/formsupport/interfaces.py
+++ b/src/collective/volto/formsupport/interfaces.py
@@ -1,3 +1,5 @@
+from plone.restapi.controlpanels.interfaces import IControlpanel
+from plone.schema import JSONField
 from zope.interface import Attribute
 from zope.interface import Interface
 from zope.interface.interfaces import IObjectEvent
@@ -69,3 +71,9 @@ IFormData = IPostAdapter
 class IDataAdapter(Interface):
     def __call__(result, block_id=None):
         pass
+
+
+class IGlobalFormStore(IControlpanel):
+    global_forms_config = JSONField(
+        title="Global forms", description="", required=True, default={}
+    )

--- a/src/collective/volto/formsupport/profiles/default/metadata.xml
+++ b/src/collective/volto/formsupport/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>1301</version>
+  <version>1302</version>
   <dependencies>
     <dependency>profile-collective.volto.otp:default</dependency>
   </dependencies>

--- a/src/collective/volto/formsupport/profiles/default/registry/main.xml
+++ b/src/collective/volto/formsupport/profiles/default/registry/main.xml
@@ -4,5 +4,6 @@
 >
 
   <!-- -*- extra stuff goes here -*- -->
+  <records interface="collective.volto.formsupport.interfaces.IGlobalFormStore" />
 
 </registry>

--- a/src/collective/volto/formsupport/restapi/__init__.py
+++ b/src/collective/volto/formsupport/restapi/__init__.py
@@ -1,0 +1,3 @@
+GLOBAL_FORM_REGISTRY_RECORD_ID = (
+    "collective.volto.formsupport.interfaces.IGlobalFormStore.global_forms_config"
+)

--- a/src/collective/volto/formsupport/restapi/deserializer/blocks.py
+++ b/src/collective/volto/formsupport/restapi/deserializer/blocks.py
@@ -1,10 +1,32 @@
+from plone.api.portal import get_registry_record
+from plone.api.portal import set_registry_record
 from plone.dexterity.interfaces import IDexterityContent
 from plone.restapi.bbb import IPloneSiteRoot
 from plone.restapi.interfaces import IBlockFieldDeserializationTransformer
 from Products.PortalTransforms.transforms.safe_html import SafeHTML
+from uuid import uuid4
 from zope.component import adapter
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
+
+
+GLOBAL_FORM_REGISTRY_RECORD_ID = (
+    "collective.volto.formsupport.interfaces.IGlobalFormStore.global_forms_config"
+)
+
+
+def update_global_forms(value):
+    global_form_id = value.get("global_form_id")
+
+    if not global_form_id:
+        global_form_id = str(uuid4())
+
+    global_forms_record = get_registry_record(GLOBAL_FORM_REGISTRY_RECORD_ID)
+    global_forms_record[global_form_id] = value
+    set_registry_record(GLOBAL_FORM_REGISTRY_RECORD_ID, global_forms_record)
+
+    value["global_form_id"] = global_form_id
+    return value
 
 
 class FormBlockDeserializerBase:
@@ -25,6 +47,7 @@ class FormBlockDeserializerBase:
         if value.get("send_message", ""):
             transform = SafeHTML()
             value["send_message"] = transform.scrub_html(value["send_message"])
+        value = update_global_forms(value)
         return value
 
 

--- a/src/collective/volto/formsupport/restapi/deserializer/blocks.py
+++ b/src/collective/volto/formsupport/restapi/deserializer/blocks.py
@@ -1,19 +1,15 @@
+from collective.volto.formsupport.restapi import GLOBAL_FORM_REGISTRY_RECORD_ID
 from plone.api.portal import get_registry_record
 from plone.api.portal import set_registry_record
 from plone.dexterity.interfaces import IDexterityContent
 from plone.restapi.bbb import IPloneSiteRoot
 from plone.restapi.interfaces import IBlockFieldDeserializationTransformer
 from Products.PortalTransforms.transforms.safe_html import SafeHTML
-from uuid import uuid4
 from zope.component import adapter
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
 
-
-GLOBAL_FORM_REGISTRY_RECORD_ID = (
-    "collective.volto.formsupport.interfaces.IGlobalFormStore.global_forms_config"
-)
-
+from uuid import uuid4
 
 def update_global_forms(value):
     global_form_id = value.get("global_form_id")

--- a/src/collective/volto/formsupport/restapi/services/submit_form/configure.zcml
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/configure.zcml
@@ -4,10 +4,12 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     >
 
+  <!-- Was for "plone.restapi.behaviors.IBlocks" but global forms
+         means any content can potentially have a form -->
   <plone:service
       method="POST"
       factory=".post.SubmitPost"
-      for="plone.restapi.behaviors.IBlocks"
+      for="plone.dexterity.interfaces.IDexterityContent"
       permission="zope2.View"
       layer="collective.volto.formsupport.interfaces.ICollectiveVoltoFormsupportLayer"
       name="@submit-form"

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -56,7 +56,7 @@ class SubmitPost(Service):
         self.form_data_adapter = getMultiAdapter(
             (self.context, self.request), IPostAdapter
         )
-        # We've already done all the work to get this data, let's re-use it.
+        # We've already done all the work to get this data, let's reuse it.
         self.form_data = self.form_data_adapter.form_data
         self.block_id = self.form_data_adapter.block_id
         self.block = self.form_data_adapter.block

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -56,11 +56,10 @@ class SubmitPost(Service):
         self.form_data_adapter = getMultiAdapter(
             (self.context, self.request), IPostAdapter
         )
-        self.form_data = self.get_form_data()
-        self.block_id = self.form_data.get("block_id", "")
-
-        if self.block_id:
-            self.block = self.get_block_data(block_id=self.block_id)
+        # We've already done all the work to get this data, let's re-use it.
+        self.form_data = self.form_data_adapter.form_data
+        self.block_id = self.form_data_adapter.block_id
+        self.block = self.form_data_adapter.block
 
     def reply(self):
         store_action = self.block.get("store", False)

--- a/src/collective/volto/formsupport/restapi/services/submit_form/post.py
+++ b/src/collective/volto/formsupport/restapi/services/submit_form/post.py
@@ -121,19 +121,6 @@ class SubmitPost(Service):
 
         return self.form_data.get("from", "") or self.block.get("default_from", "")
 
-    def get_block_data(self, block_id):
-        blocks = get_blocks(self.context)
-        if not blocks:
-            return {}
-        for id, block in blocks.items():
-            if id != block_id:
-                continue
-            block_type = block.get("@type", "")
-            if block_type != "form":
-                continue
-            return block
-        return {}
-
     def get_bcc(self):
         bcc = []
         bcc_fields = []

--- a/src/collective/volto/formsupport/upgrades.zcml
+++ b/src/collective/volto/formsupport/upgrades.zcml
@@ -40,4 +40,12 @@
       handler=".upgrades.to_1301"
       />
 
+  <genericsetup:upgradeDepends
+      title="Add global form registry entry"
+      profile="collective.volto.formsupport:default"
+      source="1301"
+      destination="1302"
+      import_steps="plone.app.registry"
+      />
+
 </configure>


### PR DESCRIPTION
This PR adds the ability for forms to be sent from outside the page they are on. The reasoning for this is so forms can be created elsewhere and inserted into a page, such as with a slots/ portlets mechanism.
This is achieved by creating a `global_forms` registry where forms are stored with a `global_block_id` which is generated on block save and saved with the block. If the client sends a form submission which matches against a global block id, that global form will be used.

## TODO

- [ ] Save data action