### PR TITLE
Use only configured fields as the csv export columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use confugured forms fields as CSV export columns.
+  [folix-01]
 
 
 3.2.1 (2025-01-09)


### PR DESCRIPTION
Basically now CSV colums are composed by all the fields found in the records + configured form fields. This pr
uses only the configured field for an CSV export