### PR TITLE
Format list values in format_fields as comma separated strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Format list values in format_fields as comma separated strings to improve readability on email messages.
+  [cekk]
 
 
 3.2.1 (2025-01-09)

--- a/src/collective/volto/formsupport/adapters/post.py
+++ b/src/collective/volto/formsupport/adapters/post.py
@@ -262,9 +262,11 @@ class PostAdapter:
 
             if field_id:
                 field_index = field_ids.index(field_id)
-
+                value = field.get("value", "")
+                if isinstance(value, list):
+                    field["value"] = ", ".join(value)
                 if self.block["subblocks"][field_index].get("field_type") == "date":
-                    field["value"] = api.portal.get_localized_time(field["value"])
+                    field["value"] = api.portal.get_localized_time(value)
 
             formatted_fields.append(field)
 

--- a/src/collective/volto/formsupport/adapters/post.py
+++ b/src/collective/volto/formsupport/adapters/post.py
@@ -149,7 +149,7 @@ class PostAdapter:
         for form_field in self.form_data.get("data", []):
             if form_field.get("field_id", "") not in email_fields:
                 continue
-            if _isemail(form_field.get("value", "")) is None:
+            if not _isemail(form_field.get("value", "")):
                 raise BadRequest(
                     translate(
                         _(

--- a/src/collective/volto/formsupport/tests/test_form_data_adapter.py
+++ b/src/collective/volto/formsupport/tests/test_form_data_adapter.py
@@ -1,9 +1,9 @@
+from collective.volto.formsupport.interfaces import IPostAdapter
 from collective.volto.formsupport.testing import VOLTO_FORMSUPPORT_INTEGRATION_TESTING
 from plone import api
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from zope.component import getMultiAdapter
-from collective.volto.formsupport.interfaces import IPostAdapter
 
 import unittest
 

--- a/src/collective/volto/formsupport/tests/test_form_data_adapter.py
+++ b/src/collective/volto/formsupport/tests/test_form_data_adapter.py
@@ -1,0 +1,45 @@
+from collective.volto.formsupport.testing import VOLTO_FORMSUPPORT_INTEGRATION_TESTING
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from zope.component import getMultiAdapter
+from collective.volto.formsupport.interfaces import IPostAdapter
+
+import unittest
+
+
+class TestFormDataAdapter(unittest.TestCase):
+    layer = VOLTO_FORMSUPPORT_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        self.portal_url = self.portal.absolute_url()
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        self.document = api.content.create(
+            type="Document",
+            title="Example context",
+            container=self.portal,
+        )
+        self.document.blocks = {
+            "form-id": {
+                "@type": "form",
+                "send": ["recipient"],
+                "subblocks": [
+                    {
+                        "field_id": "xxx",
+                        "field_type": "text",
+                    },
+                ],
+            }
+        }
+
+    def test_format_fields_join_list_values(self):
+        self.request["BODY"] = (
+            b'{"data": [{"field_id": "xxx", "value": ["a", "b"]}], "block_id": "form-id"}'
+        )
+        adapter = getMultiAdapter((self.document, self.request), IPostAdapter)
+
+        self.assertEqual(adapter.format_fields()[0]["value"], "a, b")


### PR DESCRIPTION
To improve readability on email messages