### PR TITLE
Update hCaptcha integration to use the new submit signature without r…

### DIFF
--- a/news/88.bugfix
+++ b/news/88.bugfix
@@ -1,0 +1,1 @@
+Update hCaptcha integration to use the new submit signature without remoteip, aligning with plone.formwidget.hcaptcha privacy (GDPR/LGPD) change. @alexandreIFB

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     ],
     extras_require={
         "hcaptcha": [
-            "plone.formwidget.hcaptcha>=1.0.1",
+            "plone.formwidget.hcaptcha>=1.0.3",
         ],
         "recaptcha": [
             "plone.formwidget.recaptcha",

--- a/src/collective/volto/formsupport/captcha/hcaptcha.py
+++ b/src/collective/volto/formsupport/captcha/hcaptcha.py
@@ -46,10 +46,7 @@ class HCaptchaSupport(CaptchaSupport):
                 )
             )
         token = data["token"]
-        remote_addr = self.request.get("HTTP_X_FORWARDED_FOR", "").split(",")[0]
-        if not remote_addr:
-            remote_addr = self.request.get("REMOTE_ADDR")
-        res = submit(token, self.settings.private_key, remote_addr)
+        res = submit(token, self.settings.private_key)
         if not res.is_valid:
             raise BadRequest(
                 translate(

--- a/src/collective/volto/formsupport/tests/test_captcha.py
+++ b/src/collective/volto/formsupport/tests/test_captcha.py
@@ -276,7 +276,7 @@ class TestCaptcha(unittest.TestCase):
                 },
             )
             transaction.commit()
-            mock_submit.assert_called_once_with("12345", "private", "127.0.0.1")
+            mock_submit.assert_called_once_with("12345", "private")
             self.assertEqual(response.status_code, 400)
             self.assertEqual(
                 response.json()["message"],
@@ -301,7 +301,7 @@ class TestCaptcha(unittest.TestCase):
                 },
             )
             transaction.commit()
-            mock_submit.assert_called_once_with("12345", "private", "127.0.0.1")
+            mock_submit.assert_called_once_with("12345", "private")
             self.assertEqual(response.status_code, 200)
 
     def test_get_vocabulary(self):


### PR DESCRIPTION
Update hCaptcha integration to use new submit signature (no remoteip), aligning with privacy (GDPR/LGPD) changes in plone.formwidget.hcaptcha. Removed REMOTE_ADDR usage and adjusted tests (mock without IP). Pin bumped to plone.formwidget.hcaptcha==1.0.4.

Closes #88 