### PR TITLE
Fix csv export: always insert fixed_columns as latest ones

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix csv export: always insert fixed_columns as latest ones.
+  [cekk]
 
 
 3.3.1 (2025-11-17)

--- a/src/collective/volto/formsupport/restapi/services/form_data/csv.py
+++ b/src/collective/volto/formsupport/restapi/services/form_data/csv.py
@@ -139,8 +139,8 @@ class FormDataExportGet(Service):
             rows.append(data)
 
         columns.extend(fields_labels.values())
-        columns.extend(fixed_columns)
         columns.extend(sorted(legacy_columns))
+        columns.extend(fixed_columns)
 
         writer = csv.DictWriter(sbuf, fieldnames=columns, quoting=csv.QUOTE_ALL)
         writer.writeheader()


### PR DESCRIPTION
In this way, the fixed columns (basically the date) are always the last ones.