### PR TITLE
Fix email validation when empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 3.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Do not break when an email field is an empty string in validate_email_fields. Required fields are already checked.
+  [cekk]
 
 3.3.2 (2025-12-11)
 ------------------

--- a/src/collective/volto/formsupport/adapters/post.py
+++ b/src/collective/volto/formsupport/adapters/post.py
@@ -150,7 +150,8 @@ class PostAdapter:
         for form_field in self.form_data.get("data", []):
             if form_field.get("field_id", "") not in email_fields:
                 continue
-            if not _isemail(form_field.get("value", "")):
+            value = form_field.get("value", "")
+            if value and not _isemail(value):
                 raise BadRequest(
                     translate(
                         _(

--- a/src/collective/volto/formsupport/tests/test_send_action_form.py
+++ b/src/collective/volto/formsupport/tests/test_send_action_form.py
@@ -1560,3 +1560,71 @@ class TestMailSend(unittest.TestCase):
             msg,
         )
         self.assertIn("<strong>Name:</strong> alert(=E2=80=98XSS=E2=80=99) foo", msg)
+
+    def test_email_sent_with_empty_email_field_if_not_required(self):
+        self.document.blocks = {
+            "form-id": {
+                "@type": "form",
+                "send": ["recipient"],
+                "subblocks": [
+                    {
+                        "field_id": "foo",
+                        "field_type": "text",
+                    },
+                    {
+                        "field_id": "email",
+                        "field_type": "from",
+                    },
+                ],
+            },
+        }
+        transaction.commit()
+
+        response = self.submit_form(
+            data={
+                "from": "john@doe.com",
+                "block_id": "form-id",
+                "subject": "test subject",
+                "data": [
+                    {"label": "email", "value": "", "field_id": "email"},
+                    {"label": "foo", "value": "foo", "field_id": "foo"},
+                ],
+            },
+        )
+        transaction.commit()
+        self.assertEqual(response.status_code, 200)
+
+    def test_email_not_sent_with_wrong_email_field(self):
+        self.document.blocks = {
+            "form-id": {
+                "@type": "form",
+                "send": ["recipient"],
+                "subblocks": [
+                    {
+                        "field_id": "foo",
+                        "field_type": "text",
+                    },
+                    {
+                        "field_id": "email",
+                        "field_type": "from",
+                    },
+                ],
+            },
+        }
+        transaction.commit()
+
+        response = self.submit_form(
+            data={
+                "from": "john@doe.com",
+                "block_id": "form-id",
+                "subject": "test subject",
+                "data": [
+                    {"label": "email", "value": "xxx", "field_id": "email"},
+                    {"label": "foo", "value": "foo", "field_id": "foo"},
+                ],
+            },
+        )
+        transaction.commit()
+        self.assertEqual(response.status_code, 400)
+        res = response.json()
+        self.assertEqual(res["message"], 'Email not valid in "email" field.')

--- a/tox.ini
+++ b/tox.ini
@@ -74,8 +74,8 @@ deps =
     setuptools
     z3c.dependencychecker==2.14.3
 commands =
-    python -m build --sdist
     dependencychecker
+    python -m build --sdist
 
 [testenv:dependencies-graph]
 description = generate a graph out of the dependencies of the package

--- a/tox.ini
+++ b/tox.ini
@@ -71,10 +71,10 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
+    setuptools
     z3c.dependencychecker==2.14.3
 commands =
     python -m build --sdist
-    setuptools
     dependencychecker
 
 [testenv:dependencies-graph]

--- a/tox.ini
+++ b/tox.ini
@@ -70,12 +70,13 @@ commands =
 description = check if the package defines all its dependencies
 skip_install = true
 deps =
+    setuptools>=65.0
     build
-    setuptools
     z3c.dependencychecker==2.14.3
 commands =
-    dependencychecker
+    python -m pip install --upgrade setuptools
     python -m build --sdist
+    dependencychecker
 
 [testenv:dependencies-graph]
 description = generate a graph out of the dependencies of the package

--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,7 @@ deps =
     z3c.dependencychecker==2.14.3
 commands =
     python -m build --sdist
+    setuptools
     dependencychecker
 
 [testenv:dependencies-graph]

--- a/tox.ini
+++ b/tox.ini
@@ -70,11 +70,10 @@ commands =
 description = check if the package defines all its dependencies
 skip_install = true
 deps =
-    setuptools>=65.0
+    setuptools<70.0.0
     build
     z3c.dependencychecker==2.14.3
 commands =
-    python -m pip install --upgrade setuptools
     python -m build --sdist
     dependencychecker
 


### PR DESCRIPTION
Do not break when an email field is an empty string in validate_email_fields method.

Required fields are already checked.