### PR TITLE
Upgrade to plone/meta 2.10 (adds a Plone 6.2 test matrix)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/config/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 #
 # EditorConfig Configuration file, for more details see:

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/config/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [flake8]
 doctests = 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Generated from:
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
+# See the inline comments on how to expand/tweak this configuration file
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,16 +1,10 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/config/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 name: Meta
+
 on:
   push:
-    branches:
-      - master
-      - main
-  pull_request:
-    branches:
-      - master
-      - main
   workflow_dispatch:
 
 ##
@@ -25,24 +19,21 @@ on:
 
 jobs:
   qa:
-    uses: plone/meta/.github/workflows/qa.yml@main
-  test:
-    uses: plone/meta/.github/workflows/test.yml@main
+    uses: plone/meta/.github/workflows/qa.yml@2.x
   coverage:
-    uses: plone/meta/.github/workflows/coverage.yml@main
+    uses: plone/meta/.github/workflows/coverage.yml@2.x
   dependencies:
-    uses: plone/meta/.github/workflows/dependencies.yml@main
+    uses: plone/meta/.github/workflows/dependencies.yml@2.x
   release_ready:
-    uses: plone/meta/.github/workflows/release_ready.yml@main
-#  circular:
-#    uses: plone/meta/.github/workflows/circular.yml@main
+    uses: plone/meta/.github/workflows/release_ready.yml@2.x
+  circular:
+    uses: plone/meta/.github/workflows/circular.yml@2.x
 
 ##
 # To modify the list of default jobs being created add in .meta.toml:
 # [github]
 # jobs = [
 #    "qa",
-#    "test",
 #    "coverage",
 #    "dependencies",
 #    "release_ready",
@@ -55,13 +46,6 @@ jobs:
 # when running tests/coverage jobs, add in .meta.toml:
 # [github]
 # os_dependencies = "git libxml2 libxslt"
-##
-
-##
-# To test against a specific matrix of python versions
-# when running tests jobs, add in .meta.toml:
-# [github]
-# py_versions = "['3.12', '3.11']"
 ##
 
 

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,0 +1,71 @@
+# Generated from:
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
+# See the inline comments on how to expand/tweak this configuration file
+name: Tests
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    permissions:
+      contents: read
+      pull-requests: write
+    strategy:
+      # We want to see all failures:
+      fail-fast: false
+      matrix:
+        os:
+        - ["ubuntu", "ubuntu-latest"]
+        config:
+        # [Python version, visual name, tox env]
+        - ["3.14", "6.3 on py3.14", "py314-plone63"]
+        - ["3.10", "6.3 on py3.10", "py310-plone63"]
+        - ["3.14", "6.2 on py3.14", "py314-plone62"]
+        - ["3.10", "6.2 on py3.10", "py310-plone62"]
+        - ["3.13", "6.1 on py3.13", "py313-plone61"]
+        - ["3.10", "6.1 on py3.10", "py310-plone61"]
+        - ["3.9", "6.0 on py3.9", "py39-plone60"]
+        - ["3.13", "6.0 on py3.13", "py313-plone60"]
+
+    runs-on: ${{ matrix.os[1] }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    name: ${{ matrix.config[1] }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    - name: Install uv + caching
+      uses: astral-sh/setup-uv@v8.3.2
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          setup.*
+          tox.ini
+          pyproject.toml
+        python-version: ${{ matrix.config[0] }}
+
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines_after_os_dependencies = """
+#  _your own configuration lines_
+#  """
+##
+    - name: Initialize tox
+      # the bash one-liner below does not work on Windows
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi
+    - name: Test
+      run: uvx --with tox-uv tox -e ${{ matrix.config[2] }}
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/config/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 # python related
 *.egg-info
@@ -18,8 +18,10 @@ dist/
 docs/_build
 __pycache__/
 .tox
+.vscode/
 node_modules/
-forest.*
+forest.dot
+forest.json
 
 # venv / buildout related
 bin/
@@ -36,7 +38,6 @@ parts/
 pyvenv.cfg
 var/
 local.cfg
-.python-version
 
 # mxdev
 /instance/
@@ -47,8 +48,6 @@ local.cfg
 /venv/
 .installed.txt
 
-# visual code editor
-*.code-workspace
 
 ##
 # Add extra configuration options in .meta.toml:
@@ -57,8 +56,3 @@ local.cfg
 #  _your own configuration lines_
 #  """
 ##
-temp_auto_push.bat
-temp_interactive_push.bat
-.gitignore
-.vscode/
-public/

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,6 +1,6 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/config/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "721299ce"
+commit-id = "2.10.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/config/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 ci:
     autofix_prs: false
@@ -7,20 +7,20 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 9.0.0a3
     hooks:
     -   id: isort
--   repo: https://github.com/psf/black
-    rev: 24.4.2
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.5.1
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
-    rev: 3.1.0
+    rev: 4.0.0
     hooks:
     -   id: zpretty
 
@@ -32,7 +32,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.3.0
     hooks:
     -   id: flake8
 
@@ -44,7 +44,7 @@ repos:
 #  """
 ##
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.4.2
     hooks:
     -   id: codespell
         additional_dependencies:
@@ -58,20 +58,20 @@ repos:
 #  """
 ##
 -   repo: https://github.com/mgedmin/check-manifest
-    rev: "0.49"
+    rev: "0.51"
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
-    rev: "4.2"
+    rev: "5.0.1"
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.22.0"
+    rev: "0.24.2"
     hooks:
     -   id: check-python-versions
-        args: ['--only', 'setup.py,pyproject.toml']
+        args: ['--only', 'setup.py,tox.ini']
 -   repo: https://github.com/collective/i18ndude
-    rev: "6.2.0"
+    rev: "6.3.0"
     hooks:
     -   id: i18ndude
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,46 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/config/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [build-system]
-requires = ["setuptools>=68.2"]
+requires = ["setuptools>=68.2,<82", "wheel"]
+
+
+
+[tool.towncrier]
+directory = "news/"
+filename = "CHANGES.rst"
+title_format = "{version} ({project_date})"
+underlines = ["-", ""]
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking changes:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "New features:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bug fixes:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "internal"
+name = "Internal:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "documentation"
+name = "Documentation:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "tests"
+name = "Tests:"
+showcontent = true
 
 ##
 # Add extra configuration options in .meta.toml:
@@ -24,7 +62,7 @@ profile = "plone"
 ##
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["py39"]
 
 ##
 # Add extra configuration options in .meta.toml:
@@ -35,7 +73,7 @@ target-version = ["py38"]
 ##
 
 [tool.codespell]
-ignore-words-list = "discreet,"
+ignore-words-list = "discreet,assertin,thet,"
 skip = "*.po,"
 ##
 # Add extra configuration options in .meta.toml:
@@ -83,17 +121,7 @@ Zope = [
   'Products.CMFCore', 'Products.CMFDynamicViewFTI',
 ]
 python-dateutil = ['dateutil']
-'souper.plone' = ['souper', 'repoze.catalog']
-beautifulsoup4 = ['bs4']
-# extra packages
-ignore-packages = [
-  # these are packages defined in extras_require
-  'collective.honeypot', 'plone.formwidget.hcaptcha', 'plone.formwidget.recaptcha',
-  'collective.volto.blocksfield', 'collective.z3cform.norobots',
-  'plone.app.iterate', 'plone.app.upgrade',
-  # XXX: This is a temporary fix for make the package usable with Plone  5.2 and 6.0
-  'plone.base', 'Products.CMFPlone',
-]
+pytest-plone = ['pytest', 'zope.pytestlayer', 'plone.testing', 'plone.app.testing']
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,18 +8,3 @@ ignore =
 [isort]
 profile = plone
 
-[flake8]
-# black compatible flake8 rules:
-ignore =
-    W503,
-    C812,
-    E501
-    T001
-    C813
-# E203, E266
-exclude = bootstrap.py,docs,*.egg.,omelette
-max-line-length = 88
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
-
-builtins = unicode,basestring

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 # Generated from:
-# https://github.com/plone/meta/tree/main/config/default
+# https://github.com/plone/meta/tree/2.x/src/plone/meta/default
 # See the inline comments on how to expand/tweak this configuration file
 [tox]
 # We need 4.4.0 for constrain_package_deps.
@@ -7,12 +7,37 @@ min_version = 4.4.0
 envlist =
     lint
     test
+    py314-plone63
+    py313-plone63
+    py312-plone63
+    py311-plone63
+    py310-plone63
+    py314-plone62
+    py313-plone62
+    py312-plone62
+    py311-plone62
+    py310-plone62
+    py313-plone61
+    py312-plone61
+    py311-plone61
+    py310-plone61
+    py313-plone60
+    py312-plone60
+    py311-plone60
+    py310-plone60
+    py39-plone60
     dependencies
 
 
 ##
 # Add extra configuration options in .meta.toml:
+# - to specify a custom testing combination of Plone and python versions, use `test_matrix`
+#   Use ["*"] to use all supported Python versions for this Plone version.
+# - to disable the test matrix entirely, set `use_test_matrix = false`
+# - to specify extra custom environments, use `envlist_lines`
+# - to specify extra `tox` top-level options, use `config_lines`
 #  [tox]
+#  test_matrix = {"6.2" = ["3.13", "3.12"], "6.1" = ["*"]}
 #  envlist_lines = """
 #      my_other_environment
 #  """
@@ -21,31 +46,13 @@ envlist =
 #  """
 ##
 
-[testenv]
-skip_install = true
-allowlist_externals =
-    echo
-    false
-# Make sure typos like `tox -e formaat` are caught instead of silently doing nothing.
-# See https://github.com/tox-dev/tox/issues/2858.
-commands =
-    echo "Unrecognized environment name {envname}"
-    false
-
-##
-# Add extra configuration options in .meta.toml:
-#  [tox]
-#  testenv_options = """
-#  basepython = /usr/bin/python3.8
-#  """
-##
-
 [testenv:init]
 description = Prepare environment
 skip_install = true
+allowlist_externals =
+    echo
 commands =
     echo "Initial setup complete"
-
 
 [testenv:format]
 description = automatically reformat code
@@ -71,9 +78,9 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
-    z3c.dependencychecker==2.14.3
+    z3c.dependencychecker==3.0
 commands =
-    python -m build --sdist
+    python -m build --wheel
     dependencychecker
 
 [testenv:dependencies-graph]
@@ -87,8 +94,19 @@ deps =
 commands =
     sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,zope.interface,zope.component --graph-output svg > dependencies.svg'
 
-[testenv:test]
-description = run the distribution tests
+
+[test_runner]
+deps = zope.testrunner
+test =
+    zope-testrunner --all --test-path={toxinidir}/src -s collective.volto.formsupport {posargs}
+coverage =
+    coverage run --branch --source collective.volto.formsupport {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir}/src -s collective.volto.formsupport {posargs}
+    coverage report -m --format markdown
+    coverage xml
+    coverage html
+
+[base]
+description = shared configuration for tests and coverage
 use_develop = true
 skip_install = false
 constrain_package_deps = true
@@ -104,64 +122,84 @@ set_env =
 #
 # Set constrain_package_deps .meta.toml:
 #  [tox]
-#  constrain_package_deps = "false"
+#  constrain_package_deps = false
 ##
 deps =
-    zope.testrunner
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    {[test_runner]deps}
+    plone63: -c https://dist.plone.org/release/6.3-dev/constraints.txt
+    plone62: -c https://dist.plone.org/release/6.2-dev/constraints.txt
+    plone61: -c https://dist.plone.org/release/6.1-dev/constraints.txt
+    plone60: -c https://dist.plone.org/release/6.0-dev/constraints.txt
 
 ##
 # Specify additional deps in .meta.toml:
 #  [tox]
-#  test_deps_additional = "-esources/plonegovbr.portal_base[test]"
+#  test_deps_additional = """
+#     -esources/plonegovbr.portal_base[test]
+#  """
 #
 # Specify a custom constraints file in .meta.toml:
 #  [tox]
 #  constraints_file = "https://my-server.com/constraints.txt"
 ##
-commands =
-#    rfbrowser init
-    zope-testrunner --all --test-path={toxinidir}/src -s collective.volto.formsupport {posargs}
 extras =
     test
+
 
 ##
 # Add extra configuration options in .meta.toml:
 #  [tox]
+#  skip_test_extra = true
 #  test_extras = """
 #      tests
 #      widgets
 #  """
+#
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  testenv_options = """
+#  basepython = /usr/bin/python3.8
+#  """
 ##
+
+[testenv:test]
+description = run the distribution tests
+use_develop = {[base]use_develop}
+skip_install = {[base]skip_install}
+constrain_package_deps = {[base]constrain_package_deps}
+set_env = {[base]set_env}
+deps =
+    {[test_runner]deps}
+    -c https://dist.plone.org/release/6.3-dev/constraints.txt
+
+commands = {[test_runner]test}
+extras = {[base]extras}
+
+
+[testenv]
+description = run the distribution tests (generative environments)
+use_develop = {[base]use_develop}
+skip_install = {[base]skip_install}
+constrain_package_deps = {[base]constrain_package_deps}
+set_env = {[base]set_env}
+deps = {[base]deps}
+commands = {[test_runner]test}
+extras = {[base]extras}
+
 
 [testenv:coverage]
 description = get a test coverage report
-use_develop = true
-skip_install = false
-constrain_package_deps = true
-set_env =
-    ROBOT_BROWSER=headlesschrome
-
-##
-# Specify extra test environment variables in .meta.toml:
-#  [tox]
-#  test_environment_variables = """
-#      PIP_EXTRA_INDEX_URL=https://my-pypi.my-server.com/
-#  """
-##
+use_develop = {[base]use_develop}
+skip_install = {[base]skip_install}
+constrain_package_deps = {[base]constrain_package_deps}
+set_env = {[base]set_env}
 deps =
+    {[test_runner]deps}
     coverage
-    zope.testrunner
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+    -c https://dist.plone.org/release/6.3-dev/constraints.txt
 
-commands =
-    rfbrowser init
-    coverage run --branch --source collective.volto.formsupport {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir}/src -s collective.volto.formsupport {posargs}
-    coverage report -m --format markdown
-    coverage xml
-    coverage html
-extras =
-    test
+commands = {[test_runner]coverage}
+extras = {[base]extras}
 
 
 [testenv:release-check]
@@ -170,9 +208,13 @@ skip_install = true
 deps =
     twine
     build
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
-
+    towncrier
+    -c https://dist.plone.org/release/6.3-dev/constraints.txt
 commands =
+    # fake version to not have to install the package
+    # we build the change log as news entries might break
+    # the README that is displayed on PyPI
+    towncrier build --version=100.0.0 --yes
     python -m build --sdist
     twine check dist/*
 
@@ -197,8 +239,7 @@ allowlist_externals =
 deps =
     pipdeptree
     pipforester
-    -c https://dist.plone.org/release/6.0-dev/constraints.txt
-
+    -c https://dist.plone.org/release/6.3-dev/constraints.txt
 commands =
     # Generate the full dependency tree
     sh -c 'pipdeptree -j > forest.json'


### PR DESCRIPTION
## Why

This package has **no CI signal for Plone 6.1, 6.2 or 6.3**.

`.github/workflows/meta.yml` calls `plone/meta`'s `main` workflows, and that `test.yml` takes no `plone-version` input — the job is literally named `Plone 6.0 / py${{ matrix.python-version }}`, and `tox.ini` pins `-c https://dist.plone.org/release/6.0-dev/constraints.txt`.

Plone 6.2 shipped 2026-05-19 and pairs with Volto 19, so a fair number of sites will want to know whether this add-on is safe to bring along.

## What this does

Runs `config-package` from [plone.meta 2.10.0](https://pypi.org/project/plone.meta/) — the same template `collective.sentry` already uses. It regenerates the meta-managed files and adds `test-matrix.yml` with a per-Plone-line tox factor:

```
py314-plone63 / py310-plone63
py314-plone62 / py310-plone62
py313-plone61 / py310-plone61
py39-plone60
fail-fast: false
```

The only hand edit is removing the `[flake8]` section from `setup.cfg` — the generator explicitly asks for that (`*** setup.cfg cleanup: please remove [flake8] section`); flake8 config lives in `.flake8`.

## Does it pass?

Yes, on 6.2. Before opening this I installed the package against the 6.2 constraints and ran the same `zope-testrunner` command tox does:

```console
$ pip install -e ".[test]" zope.testrunner \
    -c https://dist.plone.org/release/6.2-latest/constraints.txt
$ zope-testrunner --all --test-path=src -s collective.volto.formsupport
Ran 52 tests with 0 failures, 0 errors and 0 skipped
```

with `Products.CMFPlone 6.2.1` and `plone.restapi 10.0.2`. I also checked that `collective.volto.formsupport[test]` resolves against `6.2-dev/constraints.txt`, which is what the generated tox factor uses.

## Notes for review

- This is a **meta regeneration**, so the diff touches `pyproject.toml`, `.pre-commit-config.yaml`, `.editorconfig`, `.gitignore` and adds `.github/dependabot.yml`. That is the template's doing, not a set of opinions of mine — happy to trim anything you would rather not take.
- It will likely conflict with the open PRs here. If you would prefer this land after those, or prefer a smaller stopgap workflow that only adds the 6.2 job, say the word and I will redo it that way.
- I have not touched the classifiers. `Framework :: Plone :: 6.1` / `6.2` should follow a green run, not precede it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9wenhxQPjyRgX5fSDjf8d
